### PR TITLE
Enhancement - Use MakeMKV profiles when ripping BD/DVD

### DIFF
--- a/root/ripper/default.mmcp.xml
+++ b/root/ripper/default.mmcp.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile>
+    <!-- profile name - Default -->
+    <name lang="mogz">:5086</name>
+
+    <!-- Common MKV flags -->
+    <mkvSettings 
+        ignoreForcedSubtitlesFlag="true"
+        useISO639Type2T="false"
+        setFirstAudioTrackAsDefault="true"
+        setFirstSubtitleTrackAsDefault="true"
+        setFirstForcedSubtitleTrackAsDefault="true"
+        insertFirstChapter00IfMissing="true"
+    />
+
+    <!-- Settings overridable in preferences -->
+    <profileSettings
+        app_DefaultSelectionString="-sel:all,+sel:(favlang|nolang|single),-sel:(havemulti|havecore),-sel:mvcvideo,=100:all,-10:favlang"
+    />
+
+    <!-- Output formats currently supported by MakeMKV -->
+    <outputSettings name="copy" outputFormat="directCopy">
+        <description lang="eng">Copy track as is</description>
+        <description lang="ger">Track 1:1 kopieren</description>
+    </outputSettings>
+
+    <outputSettings name="lpcm" outputFormat="LPCM-raw">
+        <description lang="eng">Save as raw LPCM</description>
+        <description lang="ger">Als RAW LPCM speichern</description>
+    </outputSettings>
+
+    <outputSettings name="wavex" outputFormat="LPCM-wavex">
+        <description lang="eng">Save as LPCM in WAV container</description>
+        <description lang="ger">Als LPCM im WAV-Container speichern</description>
+    </outputSettings>
+
+    <outputSettings name="flac-best" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (best compression)</description>
+        <description lang="ger">Als FLAC speichern (höchste Komprimierungsstufe)</description>
+        <extraArgs>-compression_level 12</extraArgs>
+    </outputSettings>
+
+    <outputSettings name="flac-fast" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (fast compression)</description>
+        <extraArgs>-compression_level 5</extraArgs>
+    </outputSettings>
+
+    <!-- Default rule - copy as is -->
+    <trackSettings input="default">
+        <output outputSettingsName="copy" 
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Save LPCM mono or stereo as raw LPCM -->
+    <trackSettings input="LPCM-stereo">
+        <output outputSettingsName="lpcm"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Put multi-channel LPCM into WAVEX container-->
+    <trackSettings input="LPCM-multi">
+        <output outputSettingsName="wavex"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+</profile>

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -44,7 +44,7 @@ if [ "$BD1" = 'DRV:0,2,999,12,"' ]; then
  BDPATH="$STORAGE_BD"/"$DISKLABEL"
  BLURAYNUM=`echo $INFO | grep $DRIVE | cut -c5`
  mkdir -p "$BDPATH"
- makemkvcon -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >> $LOGFILE 2>&1
+ makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >> $LOGFILE 2>&1
  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
  eject $DRIVE >> $LOGFILE 2>&1
  # permissions
@@ -57,7 +57,7 @@ if [ "$BD2" = 'DRV:0,2,999,28,"' ]; then
  BDPATH="$STORAGE_BD"/"$DISKLABEL"
  BLURAYNUM=`echo $INFO | grep $DRIVE | cut -c5`
  mkdir -p "$BDPATH"
- makemkvcon -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >> $LOGFILE 2>&1
+ makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >> $LOGFILE 2>&1
  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
  eject $DRIVE >> $LOGFILE 2>&1
  # permissions
@@ -70,7 +70,7 @@ if [ "$DVD" = 'DRV:0,2,999,1,"' ]; then
  DVDPATH="$STORAGE_DVD"/"$DISKLABEL"
  DVDNUM=`echo $INFO | grep $DRIVE | cut -c5`
  mkdir -p "$DVDPATH"
- makemkvcon -r --decrypt --minlength=600 mkv disc:"$DVDNUM" all "$DVDPATH" >> $LOGFILE 2>&1
+ makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$DVDNUM" all "$DVDPATH" >> $LOGFILE 2>&1
  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
  eject $DRIVE >> $LOGFILE 2>&1
  # permissions


### PR DESCRIPTION
This patch includes the default MakeMKV profile for track/audio/subtitle selection. This patch will enable the user to customize the default track/audio/subtitle selection when ripping Blu-rays or DVDs.