### PR TITLE
Pre-Existing settings.conf file

### DIFF
--- a/root/etc/my_init.d/ripper.sh
+++ b/root/etc/my_init.d/ripper.sh
@@ -15,12 +15,12 @@ fi
 KEY=$(curl --silent 'https://www.makemkv.com/forum/viewtopic.php?f=5&t=1053'| grep -oP 'T-[\w\d@]{66}')
 
 # move settings.conf, if found
+mkdir -p /root/.MakeMKV
 if [[ -f  /config/settings.conf ]]; then
  echo "Found settings.conf. Replacing beta key file."
  cp -f  /config/settings.conf /root/.MakeMKV/
 elif ! [ "$KEY" = '' ]; then
  echo "Using MakeMKV beta key: $KEY"
- mkdir -p /root/.MakeMKV
  echo app_Key = "\"$KEY"\" > /root/.MakeMKV/settings.conf
 fi
 


### PR DESCRIPTION
If the /config/settings.conf file is already created before the docker image, /root/.MakeMKV is never created, and thus cannot be moved to the folder.

This is useful when updating the docker image.