### PR TITLE
Fix error

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -28,7 +28,7 @@ do
 cwd=$(pwd)
 cd /tmp
 rm -r *.tmp
-cd $
+cd $cwd
 
 # get disk info through makemkv and pass output to INFO
 INFO=$"`makemkvcon -r --cache=1 info disc:9999 | grep DRV:0`"


### PR DESCRIPTION
In cleaning up makemkv temp files, the ripper was not returning to the correct directory because the cd command was not using the assigned variable.