### PR TITLE
Update to qt5 as required by latest makemkv

### DIFF
--- a/root/tmp/install/install.sh
+++ b/root/tmp/install/install.sh
@@ -8,7 +8,7 @@
 #####################################
 
 apt-get update -qq
-apt-get install -qy --allow-unauthenticated build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev libqt4-dev wget
+apt-get install -qy --allow-unauthenticated build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default wget
 
 #####################################
 #	Download sources and extract    	#
@@ -55,7 +55,7 @@ popd
 #									#
 #####################################
 
-apt-get remove -qy build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev libqt4-dev
+apt-get remove -qy build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default
 apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 exit


### PR DESCRIPTION
I recently ran a build of my fork and ran into issues with makemkvcon linking properly to libmakemkv.so.1 upon launching the container. After digging into the logs from the docker image build I realized it was erroring on the makemkv build due to qt requirement. This appears to fix all the issues.