### PR TITLE
Add AAC Support via FFMPEG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN chmod +x /etc/my_init.d/*.sh
 RUN apt-get update \
  && apt-get -y --allow-unauthenticated install gddrescue ripit wget eject lame curl
  
-# MakeMKV setup by github.com/tobbenb
+# MakeMKV/FFMPEG setup by github.com/tobbenb
 RUN chmod +x /tmp/install/install.sh && sleep 1 && /tmp/install/install.sh && rm -r /tmp/install

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Data-Disk | `DATArip.sh` | Overrides data disk ripping commands in `ripper.sh` w
 
 _Note that these optional scripts must be of the specified name, have executable permissions set, and be in the same directory as `ripper.sh` to be executed._
 
+### How do I output AAC audio for CDs rather than FLAC and MP3?
+
+In the ripper.sh file, search for the line that calls `ripit`. Replace `-c 0,2` with:
+```
+-c 7 --ffmpegsuffix m4a --ffmpegopt "-c:a libfdk_aac -b:a 256k"
+```
+
 ### I want another output format that requires another piece of software!
 
 _You need to fork this image and build it yourself on docker hub. A good starting point is the [Dockerfile](https://github.com/rix1337/docker-ripper/blob/master/Dockerfile#L30) that includes setup instructions for the used ripping software.

--- a/root/tmp/install/install.sh
+++ b/root/tmp/install/install.sh
@@ -8,7 +8,7 @@
 #####################################
 
 apt-get update -qq
-apt-get install -qy --allow-unauthenticated build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default wget
+apt-get install -qy --allow-unauthenticated build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default wget libfdk-aac-dev
 
 #####################################
 #	Download sources and extract    	#
@@ -33,8 +33,13 @@ popd
 
 #FFmpeg
 pushd /tmp/sources/ffmpeg-4.0
-./configure --prefix=/tmp/ffmpeg --enable-static --disable-shared --enable-pic --disable-yasm
+./configure --prefix=/tmp/ffmpeg --enable-static --disable-shared --enable-pic --disable-yasm --enable-libfdk-aac
 make install
+popd
+
+# move ffmpeg bin files so ripit can access it
+pushd /tmp/ffmpeg/bin
+mv * /usr/bin/
 popd
 
 #Makemkv-oss
@@ -55,7 +60,15 @@ popd
 #									#
 #####################################
 
-apt-get remove -qy build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default
+apt-get remove -qy build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default libfdk-aac-dev
 apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
+
+#####################################
+#   Replace metadata for ffmpeg     #
+#   so it works with Apple Music    #
+#   and Quicktime                   #
+#####################################
+sed -i 's/author/artist/g' /usr/bin/ripit
+sed -i 's/day/year/g' /usr/bin/ripit
 
 exit


### PR DESCRIPTION
Fixes #37

* add support for Fraunhofer FDK AAC codec library to FFMPEG
* fix ripit's author metadata tag for FFMPEG
* move the FFMPEG binaries into `/usr/bin/` from the `tmp` directory