### PR TITLE
Update install.sh

### DIFF
--- a/root/tmp/install/install.sh
+++ b/root/tmp/install/install.sh
@@ -44,7 +44,7 @@ popd
 
 #Makemkv-oss
 pushd /tmp/sources/makemkv-oss-$VERSION
-PKG_CONFIG_PATH=/tmp/ffmpeg/lib/pkgconfig ./configure
+PKG_CONFIG_PATH=/tmp/ffmpeg/lib/pkgconfig CFLAGS="-std=gnu++11" ./configure
 make
 make install
 popd


### PR DESCRIPTION
I was experiencing the same issues as in issue #51 and took a look at running the dockerfile.

During the process of compiling makemkv it was creating a bunch of warnings "defaulted and deleted functions only available with -std=c++11 or -std=gnu++11" causing makemkv.so.1 to fail. 

Looking around I found the solution in this thread and it seems to be working fine now: https://www.makemkv.com/forum/viewtopic.php?f=3&t=22691&sid=fcc3af9a9b5f95774203ed2690af2884