### PR TITLE
Add perl module for parsing results from query of MusicBrains web service

### DIFF
--- a/root/ripper/MusicBrainz.pm
+++ b/root/ripper/MusicBrainz.pm
@@ -1,0 +1,103 @@
+package WebService::MusicBrainz;
+
+use strict;
+
+our $VERSION = '0.15';
+
+=head1 NAME
+
+WebService::MusicBrainz
+
+=head1 SYNOPSIS
+
+    use WebService::MusicBrainz;
+
+    my $artist_ws = WebService::MusicBrainz->new_artist();
+    my $track_ws = WebService::MusicBrainz->new_track();
+    my $release_ws = WebService::MusicBrainz->new_release();
+    my $label_ws = WebService::MusicBrainz->new_label();
+
+=head1 DESCRIPTION
+
+This module will act as a factory using static methods to return specific web service objects;
+
+=head1 METHODS
+
+=head2 new_artist()
+
+Return new instance of WebService::MusicBrainz::Artist object.
+
+=cut
+
+sub new_artist {
+   my $class = shift;
+
+   require WebService::MusicBrainz::Artist;
+
+   return WebService::MusicBrainz::Artist->new();
+}
+
+=head2 new_track
+
+Return new instance of WebService::MusicBrainz::Track object.
+
+=cut 
+
+sub new_track {
+   my $class = shift;
+
+   require WebService::MusicBrainz::Track;
+
+   return WebService::MusicBrainz::Track->new();
+}
+
+=head2 new_release
+
+Return new instance of WebService::MusicBrainz::Release object.
+
+=cut 
+
+sub new_release {
+   my $class = shift;
+
+   require WebService::MusicBrainz::Release;
+
+   return WebService::MusicBrainz::Release->new();
+}
+
+=head2 new_release
+
+Return new instance of WebService::MusicBrainz::Label object.
+
+=cut 
+
+sub new_label {
+   my $class = shift;
+
+   require WebService::MusicBrainz::Label;
+
+   return WebService::MusicBrainz::Label->new();
+}
+
+=head1 AUTHOR
+
+=over 4
+
+=item Bob Faist <bob.faist@gmail.com>
+
+=back
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2006-2007 by Bob Faist
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 SEE ALSO
+
+http://wiki.musicbrainz.org/XMLWebService
+
+=cut
+
+1;


### PR DESCRIPTION
#57 Add musicbrainz perl module.

Example ripit command line that would trigger the need for this perl module:

     /usr/bin/ripit -d "$DRIVE" -c 0,2 -W -o "$STORAGE_CD" -b 320 -mb --comment discid --playlist 0 -D '"$artist/$album"' --addtrackoffset  --infolog "/log/autorip_"$LOGFILE"" -Z 2 -O y --uppercasefirst --nointeraction >> $LOGFILE 2>&1

Note - according to docs for ripit I needed to specify '-mb' to select musicbrainz and also modify the 'comment' argument to use discid. Doing that and adding this file is all that's needed.