### PR TITLE
Switch from ripit to abcde

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.22
+FROM phusion/baseimage:focal-1.0.0
 MAINTAINER rix1337
 
 # Set correct environment variables
@@ -20,22 +20,13 @@ CMD ["/sbin/my_init"]
 
 # Move Files
 COPY root/ /
+RUN chmod 1777 /tmp
 RUN chmod +x /etc/my_init.d/*.sh
 
 # Install software
 RUN apt-get update \
  && apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject lame curl default-jre cpanminus make \
  build-essential pkgconf cmake automake autoconf git gcc tesseract-ocr libtesseract-dev libleptonica-dev libcurl4-gnutls-dev
-
-# Install ripit beta that uses gnudb instead of freedb (to detect disks)
-RUN wget http://ftp.br.debian.org/debian/pool/main/r/ripit/ripit_4.0.0~rc20161009-1_all.deb -O /tmp/install/ripit_4.0.0~rc20161009-1_all.deb \
- && apt install -y --allow-unauthenticated /tmp/install/ripit_4.0.0~rc20161009-1_all.deb \
- && rm /tmp/install/ripit_4.0.0~rc20161009-1_all.deb
- 
-# Install & update perl modules
-RUN cpanm MP3::Tag \
- && cpanm WebService::MusicBrainz
-
 
 # Install ccextractor
 RUN git clone https://github.com/CCExtractor/ccextractor.git && \
@@ -54,6 +45,10 @@ ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
 # MakeMKV/FFMPEG setup by github.com/tobbenb
 RUN chmod +x /tmp/install/install.sh && sleep 1 && \
     /tmp/install/install.sh
+
+# Install & update perl modules
+RUN cpanm WebService::MusicBrainz \
+ && cpanm -u
 
 # Clean up temp files
 RUN rm -rf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     docker-ripper:
         container_name: Ripper
         volumes:
-            - '/tmp/ripper/:/config:rw'
-            - '/tmp/ripper/:/out:rw'
+            - '/path/to/config/:/config:rw'
+            - '/path/to/rips/:/out:rw'
         devices:
             - '/dev/sr0:/dev/sr0'
             - '/dev/sg0:/dev/sg0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     docker-ripper:
         container_name: Ripper
         volumes:
-            - '/path/to/config/:/config:rw'
-            - '/path/to/rips/:/out:rw'
+            - '/tmp/ripper/:/config:rw'
+            - '/tmp/ripper/:/out:rw'
         devices:
             - '/dev/sr0:/dev/sr0'
             - '/dev/sg0:/dev/sg0'

--- a/root/ripper/abcde.conf
+++ b/root/ripper/abcde.conf
@@ -1,0 +1,98 @@
+
+# -----------------$HOME/.abcde.conf----------------- #
+# 
+# A sample configuration file to convert music cds to 
+#  MP3 format using lame, eyeD3 and abcde version 2.9.3 
+# 
+#   https://andrews-corner.org/abcde/index.html
+# -------------------------------------------------- #
+
+# Encode tracks immediately after reading. Saves disk space, gives
+# better reading of 'scratchy' disks and better troubleshooting of
+# encoding process but slows the operation of abcde quite a bit:
+LOWDISK=y
+
+# Specify the method to use to retrieve the track information,
+# the alternative is to specify 'musicbrainz':
+CDDBMETHOD=cddb
+
+# With the demise of freedb (thanks for the years of service!)
+# we move to an alternative:
+CDDBURL="http://gnudb.gnudb.org/~cddb/cddb.cgi"
+
+# Make a local cache of cddb entries and then volunteer to use 
+# these entries when and if they match the cd:
+CDDBCOPYLOCAL="y"
+CDDBLOCALDIR="$HOME/.cddb"
+CDDBLOCALRECURSIVE="y"
+CDDBUSELOCAL="y"
+
+# Specify the encoder to use for MP3. In this case 'lame':
+MP3ENCODERSYNTAX=lame 
+FLACENCODERSYNTAX=flac                    # Specify encoder for FLAC
+
+
+# Specify the path to the selected encoder. In most cases the encoder
+# should be in your $PATH as I illustrate below, otherwise you will 
+# need to specify the full path. For example: /usr/bin/lame
+LAME=lame
+FLAC=flac                                 # Path to FLAC encoder
+
+# Specify your required encoding options here. Multiple options can
+# be selected as '--preset standard --another-option' etc.
+# The '-V 2' option gives VBR encoding between 170-210 kbits/s.
+LAMEOPTS='-V 2' 
+FLACOPTS='-s -e -V -8'                    # Options for FLAC
+
+# Output type for MP3.
+OUTPUTTYPE="mp3,flac"
+
+# The cd ripping program to use. There are a few choices here: cdda2wav,
+# dagrab, cddafs (Mac OS X only) and flac. New to abcde 2.7 is 'libcdio'.
+CDROMREADERSYNTAX=cdparanoia            
+                                     
+# Give the location of the ripping program and pass any extra options,
+# if using libcdio set 'CD_PARANOIA=cd-paranoia'.
+CDPARANOIA=cdparanoia  
+CDPARANOIAOPTS="--never-skip=40"
+
+# Give the location of the CD identification program:       
+CDDISCID=cd-discid            
+                               
+# Give the base location here for the encoded music files.
+OUTPUTDIR="$STORAGE_CD"               
+
+# The default actions that abcde will take.
+ACTIONS=cddb,playlist,read,encode,tag,move,clean
+              
+# Decide here how you want the tracks labelled for a standard 'single-artist',
+# multi-track encode and also for a multi-track, 'various-artist' encode:
+OUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}-${ALBUMFILE}/${TRACKNUM}.${TRACKFILE}'
+VAOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
+
+# Decide here how you want the tracks labelled for a standard 'single-artist',
+# single-track encode and also for a single-track 'various-artist' encode.
+# (Create a single-track encode with 'abcde -1' from the commandline.)
+ONETRACKOUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}-${ALBUMFILE}/${ALBUMFILE}'
+VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}'
+
+# Create playlists for single and various-artist encodes. I would suggest
+# commenting these out for single-track encoding.
+PLAYLISTFORMAT='${OUTPUT}/${ARTISTFILE}-${ALBUMFILE}/${ALBUMFILE}.m3u'
+VAPLAYLISTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}.m3u'
+
+# This function takes out dots preceding the album name, and removes a grab
+# bag of illegal characters. It allows spaces, if you do not wish spaces add
+# in -e 's/ /_/g' after the first sed command.
+mungefilename ()
+{
+  echo "$@" | sed -e 's/^\.*//' | tr -d ":><|*/\"'?[:cntrl:]"
+}
+
+# What extra options?
+MAXPROCS=2                              # Run a few encoders simultaneously
+PADTRACKS=y                             # Makes tracks 01 02 not 1 2
+EXTRAVERBOSE=2                          # Useful for debugging
+COMMENT='abcde version 2.9.3'           # Place a comment...
+EJECTCD=y                               # Please eject cd when finished :-)
+INTERACTIVE=n

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -124,8 +124,8 @@ if [ "$CD1" = 'DRV:0,2,999,0,"' ]; then
      $ALT_RIP "$DRIVE" "$STORAGE_CD" "$LOGFILE"
   else
      # MP3 & FLAC
-     echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC"
-     /usr/bin/ripit -d "$DRIVE" -c 0,2 -W -o "$STORAGE_CD" -b 320 --comment cddbid --playlist 0 -D '"$suffix/$artist/$album"'  --infolog "/log/autorip_"$LOGFILE"" -Z 2 -O y --uppercasefirst --nointeraction >> $LOGFILE 2>&1
+     echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC" 
+     /usr/bin/abcde -d "$DRIVE" -c /config/abcde.conf -N -x -l >> $LOGFILE 2>&1
   fi
   echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
   eject $DRIVE >> $LOGFILE 2>&1

--- a/root/tmp/install/install.sh
+++ b/root/tmp/install/install.sh
@@ -2,58 +2,12 @@
 #Install script for applications
 #MakeMKV-RDP
 
-#####################################
-#	Install dependencies			#
-#									#
-#####################################
-
-apt-get update -qq
-apt-get install -qy --allow-unauthenticated build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default wget libfdk-aac-dev
-
-#####################################
-#	Download sources and extract    	#
-#	Auto-grab latest version    			#
-#####################################
-VERSION=$(curl --silent 'https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224' | grep MakeMKV.*.for.Linux.is | head -n 1 | sed -e 's/.*MakeMKV //g' -e 's/ .*//g')
-
-mkdir -p /tmp/sources
-wget -O /tmp/sources/makemkv-bin-$VERSION.tar.gz http://www.makemkv.com/download/makemkv-bin-$VERSION.tar.gz
-wget -O /tmp/sources/makemkv-oss-$VERSION.tar.gz http://www.makemkv.com/download/makemkv-oss-$VERSION.tar.gz
-wget -O /tmp/sources/ffmpeg-4.3.1.tar.bz2 https://ffmpeg.org/releases/ffmpeg-4.3.1.tar.bz2
-pushd /tmp/sources/
-tar xvzf /tmp/sources/makemkv-bin-$VERSION.tar.gz
-tar xvzf /tmp/sources/makemkv-oss-$VERSION.tar.gz
-tar xvjf /tmp/sources/ffmpeg-4.3.1.tar.bz2
-popd
-
-#####################################
-#	Compile and install				#
-#									#
-#####################################
-
-#FFmpeg
-pushd /tmp/sources/ffmpeg-4.3.1
-./configure --prefix=/tmp/ffmpeg --enable-static --disable-shared --enable-pic --disable-yasm --enable-libfdk-aac
-make install
-popd
-
-# move ffmpeg bin files so ripit can access it
-pushd /tmp/ffmpeg/bin
-mv * /usr/bin/
-popd
-
-#Makemkv-oss
-pushd /tmp/sources/makemkv-oss-$VERSION
-PKG_CONFIG_PATH=/tmp/ffmpeg/lib/pkgconfig CFLAGS="-std=gnu++11" ./configure
-make
-make install
-popd
-
-#Makemkv-bin
-pushd /tmp/sources/makemkv-bin-$VERSION
-/bin/echo -e "yes" | make install
-popd
-
+add-apt-repository ppa:heyarje/makemkv-beta
+apt-get update
+apt-get -y install makemkv-bin makemkv-oss
+apt-get -y install abcde eyed3
+apt-get -y install flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2
+apt-get -y autoremove
 
 #####################################
 #	Remove unneeded packages		#
@@ -62,13 +16,5 @@ popd
 
 apt-get remove -qy build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qt5-default libfdk-aac-dev
 apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
-
-#####################################
-#   Replace metadata for ffmpeg     #
-#   so it works with Apple Music    #
-#   and Quicktime                   #
-#####################################
-sed -i 's/author/artist/g' /usr/bin/ripit
-sed -i 's/day/year/g' /usr/bin/ripit
 
 exit


### PR DESCRIPTION
abcde seems more mature then ripit and actively developed.
Also abcde doesn't have the problems with umlauts.
readme has to be fixed and probably some dependencies or apt repos can be removed.

I tested it with cd's and it's working
Base distro changed to focal instead of the old 0.92.2

DVD / Blueray package moved from self compiled to ppa.
