### PR TITLE
MakeMKV-Forum changed URL, Beta-Key can be obtained using new URL

### DIFF
--- a/root/etc/my_init.d/ripper.sh
+++ b/root/etc/my_init.d/ripper.sh
@@ -14,7 +14,7 @@ if [[ ! -f /config/settings.conf ]] && [[  ! -f /config/enter-your-key-then-rena
 fi
 
 # fetching MakeMKV beta key
-KEY=$(curl --silent 'https://www.makemkv.com/forum/viewtopic.php?f=5&t=1053'| grep -oP 'T-[\w\d@]{66}')
+KEY=$(curl --silent 'https://forum.makemkv.com/forum/viewtopic.php?f=5&t=1053' | grep -oP 'T-[\w\d@]{66}')
 
 # move settings.conf, if found
 mkdir -p /root/.MakeMKV


### PR DESCRIPTION
The URL for the MakeMKV-Forum was changed from [https://www.makemkv.com/forum/] to [https://forum.makemkv.com/forum/]...  
...using the new URL, the Beta-Key can still be obtained the same way as before.