### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", ENV{ID_CDROM_MEDIA_TRACK_COUNT_DAT
 ##  IMPORT{builtin}="blkid --noraid"
 ```
 
-_You can comment these lines out or delete them all together, then replace them with the GOTO lines. You may then either reboot OR reload the rules. If you're using Unraid, you'll need to edit the the original udev rule and reload._
+_You can comment these lines out or delete them all together, then replace them with the GOTO lines. You may then either reboot OR reload the rules. If you're using Unraid, you'll need to edit the original udev rule and reload._
 ```
 root@linuxbox# udevadm control --reload-rules && udevadm trigger
 ```


### PR DESCRIPTION
Common flaw affecting multiple linux distros. It causes udev to hang on /dev/sr0 after inserting some video discs which causes udev to kill off /dev/sr0. this can result in docker hanging, crashing, and/or creating unkilllable makemkv zombie processes. Only certain discs appear to trigger it, but its been about 1 in 10 here lately.

additional details: https://forum.makemkv.com/forum/viewtopic.php?t=25357