### PR TITLE
Enhancements to Disk Ripping Script and Docker Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ venv
 # PyCharm
 .idea
 .eggs
-root/ripper/ripper-old.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ venv
 # PyCharm
 .idea
 .eggs
+root/ripper/ripper-old.sh

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Check the device mount points and optional settings before you run the container
 - `ALSOMAKEISO`: Optional - If `true`, creates an additional ISO image alongside the normal rip operation. Default is `false`.
 - `TIMESTAMPPREFIX`: Optional - If `true`, prefixes output folders with a timestamp for organization. Default is `false`.
 - `MINIMUMLENGTH`: Optional - The minimum length of a title in seconds to be considered valid.(Applies to DVD and BluRAY) Default is `600`.
+- `PREFIX`: Optional - path prefix for the integrated web ui when commented out or set to /, the web ui will be at the root of the server
+- `USER`: Optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
+- `PASS`: Optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication
 
 ### Building and Running with Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -261,3 +261,5 @@ root@linuxbox# udevadm control --reload-rules && udevadm trigger
 - [MakeMKV Setup for manual-build by tianon](https://github.com/tianon/dockerfiles/blob/master/makemkv/Dockerfile)
 
 - [MakeMKV key/version fetcher by metalight](http://blog.metalight.dk/2016/03/makemkv-wrapper-with-auto-updater.html)
+
+- [General cleanup and exposing customization options to the user by jeeshofone](https://123cloud.st)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Add these optional parameters when running the container
   -e /ripper-ui=OPTIONAL_WEB_UI_PATH_PREFIX \ 
   -e myusername=OPTIONAL_WEB_UI_USERNAME \ 
   -e strongpassword=OPTIONAL_WEB_UI_PASSWORD \
+  -e DEBUGTOWEB=true \
 ````
 
 `OPTIONAL_WEB_UI_USERNAME ` and `OPTIONAL_WEB_UI_PASSWORD ` both need to be set to enable http basic auth for the web UI.
@@ -88,7 +89,7 @@ launch. Without a purchased license key Ripper may stop running at any time.
 
 ## Docker compose
 
-Check the device mount points and optional settings before you run the container!
+Check the device mount points and optional settings before you run the container.
 
 `docker-compose up -d`
 
@@ -120,10 +121,16 @@ First clone the repository:
 
 You can build and run docker-ripper using Docker Compose, which simplifies the process of deploying and managing containers
 
+You can build two different versions of the image "latest" and "manual-build"
+
+Manual-build is the recommended version, as it is updated much faster to newly released makemkv versions - that are required when running with the free beta key.
+"latest" is based on the latest makemkv version available in the Ubuntu PPA. This version is more stable, but might not work with the free beta key for a while after a new makemkv version is released. It will build faster, as it does not need to compile makemkv from source.
+
+Make sure to uncomment the version you want to build in the docker-compose.yml file build section and comment out the pre-built image tag `#image: rix1337/docker-ripper:latest`
+
 - To build the image:
   
-  ```docker-compose build```
-This will use the latest/Dockerfile to build an image tagged as `rix1337/docker-ripper:latest`.
+  ```docker-compose build``` or ```docker-compose build --no-cache```
 
 - To start the container:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This will use the latest/Dockerfile to build an image tagged as `rix1337/docker-
 
 To start the container:
 
-```docker-compose up -d``` or ```docker-compose up``
+```docker-compose up -d``` or ```docker-compose up```
 This command with the `-d` flag will start the container in detached mode, meaning it will run in the background. Without the `-d` flag, the container will run in the foreground and log to the console. You can stop the container with `docker-compose stop` or `docker-compose down`. The latter will also remove the container. 
 
 Logs can be viewed with `docker-compose logs` or `docker-compose logs -f` to follow the logs in real time.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ launch. Without a purchased license key Ripper may stop running at any time.
 3) At this point your config directory should look like this:  
    ![config directory](https://raw.githubusercontent.com/rix1337/docker-ripper/main/.github/screenshots/configdirectory.png)
 
-# Docker compose
+## Docker compose
 
 Check the device mount points and optional settings before you run the container!
 
@@ -109,7 +109,7 @@ Check the device mount points and optional settings before you run the container
 - `TIMESTAMPPREFIX`: Optional - If `true`, prefixes output folders with a timestamp for organization. Default is `false`.
 - `MINIMUMLENGTH`: Optional - The minimum length of a title in seconds to be considered valid.(Applies to DVD and BluRAY) Default is `600`.
 
-## Building and Running with Docker Compose
+### Building and Running with Docker Compose
 
 First clone the repository:
 

--- a/README.md
+++ b/README.md
@@ -125,16 +125,18 @@ You can build and run docker-ripper using Docker Compose, which simplifies the p
   ```docker-compose build```
 This will use the latest/Dockerfile to build an image tagged as `rix1337/docker-ripper:latest`.
 
-To start the container:
+- To start the container:
 
 ```docker-compose up -d``` or ```docker-compose up```
 This command with the `-d` flag will start the container in detached mode, meaning it will run in the background. Without the `-d` flag, the container will run in the foreground and log to the console. You can stop the container with `docker-compose stop` or `docker-compose down`. The latter will also remove the container. 
+
+- Logs
 
 Logs can be viewed with `docker-compose logs` or `docker-compose logs -f` to follow the logs in real time.
 
 If you prefer to build the Docker image manually without Docker Compose, you can use the docker build command:
 
-To build the "latest" image using Docker:
+To build the "latest" image using docker build:
 
 ```docker build -f latest/Dockerfile -t rix1337/docker-ripper:latest .```
 

--- a/README.md
+++ b/README.md
@@ -94,20 +94,52 @@ Check the device mount points and optional settings before you run the container
 
 ### Environment Variables
 
-- `EJECTENABLED`: If set to `true`, the disc is ejected after ripping is completed. Default is `true`.
-- `JUSTMAKEISO`: If `true`, only an ISO of the disc is created. Default is `false`.
-- `STORAGE_CD`: The path for storing ripped CD content. Default is `/out/Ripper/CD`.
-- `STORAGE_DATA`: The path for storing data disc ISOs. Default is `/out/Ripper/DATA`.
-- `STORAGE_DVD`: The path for storing ripped DVD content. Default is `/out/Ripper/DVD`.
-- `STORAGE_BD`: The path for storing ripped BluRay content. Default is `/out/Ripper/BluRay`.
-- `DRIVE`: The device file for the optical drive (e.g., `/dev/sr0`). Default is `/dev/sr0`.
-- `BAD_THRESHOLD`: The number of allowed consecutive bad read attempts before failing. Default is `5`.
-- `DEBUG`: Enables verbose logging when set to `true`. Default is `false`.
-- `DEBUGTOWEB`: If `true`, debug logs are published to the web UI. Default is `false`.
-- `SEPARATERAWFINISH`: When `true`, separates raw and final rips into different directories. Default is `false`.
-- `ALSOMAKEISO`: If `true`, creates an additional ISO image alongside the normal rip. Default is `false`.
-- `TIMESTAMPPREFIX`: If `true`, prefixes output folders with a timestamp for organization. Default is `false`.
-- `MINIMUMLENGTH`: The minimum length of a title in seconds to be considered valid.(Applies to DVD and BluRAY) Default is `600`.
+- `EJECTENABLED`: Optional - If set to `true`, the disc is ejected after ripping is completed. Default is `true`.
+- `JUSTMAKEISO`: Optional - If `true`, only an ISO of the disc is created. Default is `false`.
+- `STORAGE_CD`: Optional - The path for storing ripped CD content. Default is `/out/Ripper/CD`.
+- `STORAGE_DATA`: Optional - The path for storing data disc ISOs. Default is `/out/Ripper/DATA`.
+- `STORAGE_DVD`: Optional - The path for storing ripped DVD content. Default is `/out/Ripper/DVD`.
+- `STORAGE_BD`: Optional - The path for storing ripped BluRay content. Default is `/out/Ripper/BluRay`.
+- `DRIVE`: Optional - The device file for the optical drive (e.g., `/dev/sr0`). Default is `/dev/sr0`.
+- `BAD_THRESHOLD`: Optional - The number of allowed consecutive bad read attempts before failing. Default is `5`.
+- `DEBUG`: Optional - Enables verbose logging when set to `true`. Default is `false`.
+- `DEBUGTOWEB`: Optional - If `true`, debug logs are published to the web UI. Default is `false`.
+- `SEPARATERAWFINISH`: Optional - When `true`, separates raw and final rips into different directories. Default is `false`.
+- `ALSOMAKEISO`: Optional - If `true`, creates an additional ISO image alongside the normal rip operation. Default is `false`.
+- `TIMESTAMPPREFIX`: Optional - If `true`, prefixes output folders with a timestamp for organization. Default is `false`.
+- `MINIMUMLENGTH`: Optional - The minimum length of a title in seconds to be considered valid.(Applies to DVD and BluRAY) Default is `600`.
+
+## Building and Running with Docker Compose
+
+First clone the repository:
+
+```git clone https://github.com/rix1337/docker-ripper.git```
+
+You can build and run docker-ripper using Docker Compose, which simplifies the process of deploying and managing containers
+
+- To build the image:
+  
+  ```docker-compose build```
+This will use the latest/Dockerfile to build an image tagged as `rix1337/docker-ripper:latest`.
+
+To start the container:
+
+```docker-compose up -d``` or ```docker-compose up``
+This command with the `-d` flag will start the container in detached mode, meaning it will run in the background. Without the `-d` flag, the container will run in the foreground and log to the console. You can stop the container with `docker-compose stop` or `docker-compose down`. The latter will also remove the container. 
+
+Logs can be viewed with `docker-compose logs` or `docker-compose logs -f` to follow the logs in real time.
+
+If you prefer to build the Docker image manually without Docker Compose, you can use the docker build command:
+
+To build the "latest" image using Docker:
+
+```docker build -f latest/Dockerfile -t rix1337/docker-ripper:latest .```
+
+This command performs the same operation as the docker-compose build but requires manual input of build context and parameters.
+
+Remember to periodically pull the latest changes from the git repository to keep your Dockerfile up to date and rebuild the image if any updates have been made.
+
+
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This container will detect optical disks by their type and rip them automaticall
 
 Disc Type | Output | Tools used
 ---|---|---
-CD | MP3 and FLAC | abcde (lame and flac)
-Data-Disk | Uncompressed .ISO | ddrescue
-DVD | MKV | MakeMKV
-BluRay | MKV | MakeMKV
+CD | MP3 FLAC ISO | abcde (lame and flac), ddrescue
+Data-Disk | ISO | ddrescue
+DVD | MKV and ISO | MakeMKV, ddrescue
+BluRay | MKV and ISO | MakeMKV, ddrescue
 
 ### Prerequistites
 
@@ -91,6 +91,23 @@ launch. Without a purchased license key Ripper may stop running at any time.
 Check the device mount points and optional settings before you run the container!
 
 `docker-compose up -d`
+
+### Environment Variables
+
+- `EJECTENABLED`: If set to `true`, the disc is ejected after ripping is completed. Default is `true`.
+- `JUSTMAKEISO`: If `true`, only an ISO of the disc is created. Default is `false`.
+- `STORAGE_CD`: The path for storing ripped CD content. Default is `/out/Ripper/CD`.
+- `STORAGE_DATA`: The path for storing data disc ISOs. Default is `/out/Ripper/DATA`.
+- `STORAGE_DVD`: The path for storing ripped DVD content. Default is `/out/Ripper/DVD`.
+- `STORAGE_BD`: The path for storing ripped BluRay content. Default is `/out/Ripper/BluRay`.
+- `DRIVE`: The device file for the optical drive (e.g., `/dev/sr0`). Default is `/dev/sr0`.
+- `BAD_THRESHOLD`: The number of allowed consecutive bad read attempts before failing. Default is `5`.
+- `DEBUG`: Enables verbose logging when set to `true`. Default is `false`.
+- `DEBUGTOWEB`: If `true`, debug logs are published to the web UI. Default is `false`.
+- `SEPARATERAWFINISH`: When `true`, separates raw and final rips into different directories. Default is `false`.
+- `ALSOMAKEISO`: If `true`, creates an additional ISO image alongside the normal rip. Default is `false`.
+- `TIMESTAMPPREFIX`: If `true`, prefixes output folders with a timestamp for organization. Default is `false`.
+- `MINIMUMLENGTH`: The minimum length of a title in seconds to be considered valid.(Applies to DVD and BluRAY) Default is `600`.
 
 # FAQ
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     docker-ripper:
         container_name: Ripper
         volumes:
-            - ./ripper-config:/config:rw
+            #- ./ripper-config:/config:rw # optional - path to the config folder - if not provided, a default config will be used
             - ./ripper-output:/out:rw
         devices:
             - /dev/sr0:/dev/sr0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: '3.3'
 services:
     docker-ripper:
+        build:
+            context: ./latest
+            dockerfile: Dockerfile
+        image: rix1337/docker-ripper:latest
         container_name: Ripper
         volumes:
             #- ./ripper-config:/config:rw # optional - path to the config folder - if not provided, a default config will be used
@@ -27,5 +31,3 @@ services:
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication
         privileged: true
-        build:
-            dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             - STORAGE_DATA=/out/Ripper/Data # required - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
             - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
             - JUSTMAKEISO=false # optional - true/false just making an ISO of any disk
+            - DEBUG=true # optional - true/false - enable debug logging
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ version: '3.3'
 services:
     docker-ripper:
         container_name: Ripper
+        build:
+            dockerfile: latest/Dockerfile
+        image: rix1337/docker-ripper:latest
         volumes:
             #- ./ripper-config:/config:rw # optional - path to the config folder - if not provided, a default config will be used
             - ./ripper-output:/out:rw
@@ -28,5 +31,3 @@ services:
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication
         privileged: true
-        build:
-            dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         ports:
             - 9090:9090 
         environment:
+             - EJECTENABLED=false # required - enable/disable ejecting of the disc after ripping
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
             - 9090:9090 
         environment:
             - SEPARATERAWFINISH=true # optional - true/false - separate the raw files from the finished files
-            - EJECTENABLED=false # required - true/false - eject the disc when finished
-            - STORAGE_CD=/out/Ripper/CD # required - path to the storage folder for CD rips - should be to a folder in the mounted /out volume
-            - STORAGE_DVD=/out/Ripper/DVD # required - path to the storage folder for DVD rips - should be to a folder in the mounted /out volume
-            - STORAGE_BD=/out/Ripper/BluRay # required - path to the storage folder for BD rips - should be to a folder in the mounted /out volume
-            - STORAGE_DATA=/out/Ripper/Data # required - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
-            - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
+            - EJECTENABLED=true # optional - true/false - eject the disc when finished
+            - STORAGE_CD=/out/Ripper/CD # optional - path to the storage folder for CD rips - should be to a folder in the mounted /out volume
+            - STORAGE_DVD=/out/Ripper/DVD # optional - path to the storage folder for DVD rips - should be to a folder in the mounted /out volume
+            - STORAGE_BD=/out/Ripper/BluRay # optional - path to the storage folder for BD rips - should be to a folder in the mounted /out volume
+            - STORAGE_DATA=/out/Ripper/Data # optional - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
+            - DRIVE=/dev/sr0 # optional - path to the optical drive - should be to the mounted /dev/sr0 device
             - JUSTMAKEISO=false # optional - true/false just making an ISO of any disc
             - ALSOMAKEISO=false # optional - true/false - will do the normal rip and also make an ISO of every disc
             - TIMESTAMPPREFIX=false # optional - true/false - prefix the output folder with a timestamp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,18 +12,19 @@ services:
             - 9090:9090 
         environment:
             - SEPARATERAWFINISH=true # optional - true/false - separate the raw files from the finished files
-            - EJECTENABLED=false # required - true/false - eject the disk when finished
+            - EJECTENABLED=false # required - true/false - eject the disc when finished
             - STORAGE_CD=/out/Ripper/CD # required - path to the storage folder for CD rips - should be to a folder in the mounted /out volume
             - STORAGE_DVD=/out/Ripper/DVD # required - path to the storage folder for DVD rips - should be to a folder in the mounted /out volume
             - STORAGE_BD=/out/Ripper/BluRay # required - path to the storage folder for BD rips - should be to a folder in the mounted /out volume
             - STORAGE_DATA=/out/Ripper/Data # required - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
             - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
-            - JUSTMAKEISO=false # optional - true/false just making an ISO of any disk
-            - DEBUG=true # optional - true/false - enable debug logging
+            - JUSTMAKEISO=false # optional - true/false just making an ISO of any disc
+            - ALSOMAKEISO=false # optional - true/false - will do the normal rip and also make an ISO of every disc
+            - DEBUG=false # optional - true/false - enable debug logging
             - DEBUGTOWEB=false # optional - true/false - enable debug logging to the web ui
-        #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
-        #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
-        #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)
+        #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui when commented out or set to /, the web ui will be at the root of the server
+        #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
+        #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication
         privileged: true
         build:
             dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 version: '3.3'
 services:
     docker-ripper:
-        build:
-            context: ./latest
-            dockerfile: Dockerfile
-        image: rix1337/docker-ripper:latest
         container_name: Ripper
         volumes:
             #- ./ripper-config:/config:rw # optional - path to the config folder - if not provided, a default config will be used
@@ -31,3 +27,5 @@ services:
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication
         privileged: true
+        build:
+            dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,14 @@ services:
         ports:
             - 9090:9090 
         environment:
-             - EJECTENABLED=false # required - enable/disable ejecting of the disc after ripping
+            - SEPARATERAWFINISH=true # optional - enable/disable the creation of a separate raw folder - Finished Rips are moved to a "finished" folder in it's respective STORAGE folder
+            - EJECTENABLED=false # required - enable/disable ejecting of the disc after ripping
+            - STORAGE_CD=/out/Ripper/CD # required - path to the storage folder for CD rips - should be to a folder in the mounted /out volume
+            - STORAGE_DVD=/out/Ripper/DVD # required - path to the storage folder for DVD rips - should be to a folder in the mounted /out volume
+            - STORAGE_BD=/out/Ripper/BluRay # required - path to the storage folder for BD rips - should be to a folder in the mounted /out volume
+            - STORAGE_DATA=/out/Ripper/Data # required - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
+            - DRIVE=/dev/sr0 # required - path to the optical drive
+            - JUSTMAKEISO=false # optional - enable/disable just making an ISO of any disk
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,6 @@ services:
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)
-        #privileged: true # optional - only use when your drive is not detected inside the container
+        privileged: true
         build:
             dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
             - TIMESTAMPPREFIX=false # optional - true/false - prefix the output folder with a timestamp
             - DEBUG=false # optional - true/false - enable debug logging
             - DEBUGTOWEB=false # optional - true/false - enable debug logging to the web ui
+            - MINIMUMLENGTH=600 # optional - minimum length of the disc in seconds - if the disc or chapter is shorter than this, it will not be ripped
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui when commented out or set to /, the web ui will be at the root of the server
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set) - if not set, the web ui will not require authentication
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set) - if not set, the web ui will not require authentication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
             - JUSTMAKEISO=false # optional - true/false just making an ISO of any disk
             - DEBUG=true # optional - true/false - enable debug logging
+            - DEBUGTOWEB=false # optional - true/false - enable debug logging to the web ui
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
             - JUSTMAKEISO=false # optional - true/false just making an ISO of any disc
             - ALSOMAKEISO=false # optional - true/false - will do the normal rip and also make an ISO of every disc
+            - TIMESTAMPPREFIX=false # optional - true/false - prefix the output folder with a timestamp
             - DEBUG=false # optional - true/false - enable debug logging
             - DEBUGTOWEB=false # optional - true/false - enable debug logging to the web ui
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui when commented out or set to /, the web ui will be at the root of the server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,17 @@ services:
     docker-ripper:
         container_name: Ripper
         volumes:
-            - '/path/to/config/:/config:rw'
-            - '/path/to/rips/:/out:rw'
+            - ./ripper-config:/config:rw
+            - ./ripper-output:/out:rw
         devices:
-            - '/dev/sr0:/dev/sr0'
-            - '/dev/sg0:/dev/sg0'
+            - /dev/sr0:/dev/sr0
+            - /dev/sg0:/dev/sg0
         ports:
-            - 'port:9090' # optional - port for the integrated web ui
+            - 9090:9090 
         environment:
-            - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
-            - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
-            - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)
-        privileged: true # optional - only use when your drive is not detected inside the container
-        image: rix1337/docker-ripper:manual-latest
+        #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
+        #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
+        #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)
+        #privileged: true # optional - only use when your drive is not detected inside the container
+        build:
+            dockerfile: latest/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@ version: '3.3'
 services:
     docker-ripper:
         container_name: Ripper
-        build:
-            dockerfile: latest/Dockerfile
-        image: rix1337/docker-ripper:latest
+        #build: # optional - use this if you want to build the image yourself
+        #   dockerfile: latest/Dockerfile # this uses the repo version of makemkvcon
+        #   dockerfile: manual-build/Dockerfile # this will build makeMKV from source - this takes a long time but will always be the latest version
+        image: rix1337/docker-ripper:latest 
         volumes:
             #- ./ripper-config:/config:rw # optional - path to the config folder - if not provided, a default config will be used
             - ./ripper-output:/out:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
         ports:
             - 9090:9090 
         environment:
-            - SEPARATERAWFINISH=true # optional - enable/disable the creation of a separate raw folder - Finished Rips are moved to a "finished" folder in it's respective STORAGE folder
-            - EJECTENABLED=false # required - enable/disable ejecting of the disc after ripping
+            - SEPARATERAWFINISH=true # optional - true/false - separate the raw files from the finished files
+            - EJECTENABLED=false # required - true/false - eject the disk when finished
             - STORAGE_CD=/out/Ripper/CD # required - path to the storage folder for CD rips - should be to a folder in the mounted /out volume
             - STORAGE_DVD=/out/Ripper/DVD # required - path to the storage folder for DVD rips - should be to a folder in the mounted /out volume
             - STORAGE_BD=/out/Ripper/BluRay # required - path to the storage folder for BD rips - should be to a folder in the mounted /out volume
             - STORAGE_DATA=/out/Ripper/Data # required - path to the storage folder for Data rips - should be to a folder in the mounted /out volume
-            - DRIVE=/dev/sr0 # required - path to the optical drive
-            - JUSTMAKEISO=false # optional - enable/disable just making an ISO of any disk
+            - DRIVE=/dev/sr0 # required - path to the optical drive - should be to the mounted /dev/sr0 device
+            - JUSTMAKEISO=false # optional - true/false just making an ISO of any disk
         #    - PREFIX=OPTIONAL_WEB_UI_PATH_PREFIX # optional - path prefix for the integrated web ui
         #    - USER=OPTIONAL_WEB_UI_USERNAME # optional - user name for the integrated web ui (requires PASS to be set)
         #    - PASS=OPTIONAL_WEB_UI_PASSWORD # optional - password for the integrated web ui (requires USER to be set)

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -24,15 +24,11 @@ RUN chmod +x /etc/my_init.d/*.sh
 
 # Install software
 RUN apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git && \
-    apt-get -y install abcde eyed3 && \
-    apt-get -y install flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 && \
+    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 docopt flask waitress && \
     apt-get -y autoremove
 
 # Install python for web ui
-RUN apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends python3 python3-pip && \
-    pip3 install docopt flask waitress
+RUN pip3 install docopt flask waitress
 
  # Disable SSH
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -13,6 +13,9 @@ RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
 
+# Invalidate build cache on new releases of MakeMKV
+ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
+
 # Install software
 RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \
     apt-get update && \
@@ -46,9 +49,6 @@ RUN pip3 install --no-cache-dir \
     docopt \
     flask \
     waitress
-
-# Invalidate build cache on new releases of MakeMKV
-ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
 
 # Move Files and set permissions
 COPY root/ /

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /etc/my_init.d/*.sh
 
 # Install software
 RUN apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 docopt flask waitress && \
+    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 && \
     apt-get -y autoremove
 
 # Install python for web ui

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -8,6 +8,9 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+ # Disable SSH
+RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
 
@@ -16,24 +19,16 @@ COPY root/ /
 RUN chmod +x /etc/my_init.d/*.sh
 
 # Install software
-RUN apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 && \
+RUN add-apt-repository ppa:heyarje/makemkv-beta \
+    apt-get update && \
+    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 makemkv-bin makemkv-oss ccextractor && \
     apt-get -y autoremove
 
 # Install python for web ui
 RUN pip3 install docopt flask waitress
 
- # Disable SSH
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-
 # invalidate build cache on repo build
 ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" latest_build
-
-# Install MakeMKV
-RUN add-apt-repository ppa:heyarje/makemkv-beta && \
-    apt-get update && \
-    apt-get -y install makemkv-bin makemkv-oss ccextractor && \
-    apt-get -y autoremove
 
 # Clean up temp files
 RUN rm -rf \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,37 +1,55 @@
 FROM phusion/baseimage:focal-1.0.0
 LABEL maintainer="rix1337"
 
-# Set correct environment variables
-ENV HOME /root
-ENV DEBIAN_FRONTEND noninteractive
-ENV LC_ALL C.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=C.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    HOME=/root
 
- # Disable SSH
+# Disable SSH
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
 
-# Move Files
+# Install software
+RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      abcde \
+      ccextractor \
+      eject \
+      eyed3 \
+      flac \
+      gddrescue \
+      git \
+      id3 \
+      id3v2 \
+      lame \
+      makemkv-bin \
+      makemkv-oss \
+      mkcue \
+      python3 \
+      python3-pip \
+      sdparm \
+      speex \
+      vorbis-tools \
+      vorbisgain \
+      wget && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install python packages for web ui
+RUN pip3 install --no-cache-dir \
+    docopt \
+    flask \
+    waitress
+
+# Invalidate build cache on new releases of MakeMKV
+ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
+
+# Move Files and set permissions
 COPY root/ /
 RUN chmod +x /etc/my_init.d/*.sh
-
-# Install software
-RUN add-apt-repository ppa:heyarje/makemkv-beta &&\
-    apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 makemkv-bin makemkv-oss ccextractor && \
-    apt-get -y autoremove
-
-# Install python for web ui
-RUN pip3 install docopt flask waitress
-
-# invalidate build cache on repo build
-ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" latest_build
-
-# Clean up temp files
-RUN rm -rf \
-    	/tmp/* \
-    	/var/lib/apt/lists/* \
-    	/var/tmp/*

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -11,13 +11,6 @@ ENV LANGUAGE en_US.UTF-8
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
 
-# Configure user nobody to match unRAID's settings
-RUN \
- usermod -u 99 nobody && \
- usermod -g 100 nobody && \
- usermod -d /home nobody && \
- chown -R nobody:users /home
-
 # Move Files
 COPY root/ /
 RUN chmod +x /etc/my_init.d/*.sh

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 CMD ["/sbin/my_init"]
 
 # Invalidate build cache on new releases of MakeMKV
-# ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
+ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
 
 # Install software
 RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -19,7 +19,7 @@ COPY root/ /
 RUN chmod +x /etc/my_init.d/*.sh
 
 # Install software
-RUN add-apt-repository ppa:heyarje/makemkv-beta \
+RUN add-apt-repository ppa:heyarje/makemkv-beta &&\
     apt-get update && \
     apt-get -y --allow-unauthenticated install --no-install-recommends gddrescue wget eject sdparm git python3 python3-pip abcde eyed3 flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 makemkv-bin makemkv-oss ccextractor && \
     apt-get -y autoremove

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:focal-1.0.0
-MAINTAINER rix1337
+LABEL maintainer="rix1337"
 
 # Set correct environment variables
 ENV HOME /root

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 CMD ["/sbin/my_init"]
 
 # Invalidate build cache on new releases of MakeMKV
-ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
+# ADD "https://launchpad.net/~heyarje/+archive/ubuntu/makemkv-beta/+builds?build_text=makemkv-bin&build_state=built" /dev/null
 
 # Install software
 RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \

--- a/manual-build/Dockerfile
+++ b/manual-build/Dockerfile
@@ -1,49 +1,56 @@
 FROM phusion/baseimage:focal-1.0.0
 LABEL maintainer="rix1337"
 
-# Set correct environment variables
-ENV HOME /root
-ENV DEBIAN_FRONTEND noninteractive
-ENV LC_ALL C.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/root \
+    LC_ALL=C.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
 
 # Configure user nobody to match unRAID's settings
-RUN \
- usermod -u 99 nobody && \
- usermod -g 100 nobody && \
- usermod -d /home nobody && \
- chown -R nobody:users /home
+RUN usermod -u 99 nobody && \
+    usermod -g 100 nobody && \
+    usermod -d /home nobody && \
+    chown nobody:users /home -R
 
-# Move Files
-COPY root/ /
-COPY manual-build/install/ /install
-RUN chmod +x /etc/my_init.d/*.sh && \
-  chmod -R 777 /tmp && \
-  chmod -R 777 /install
+# Invalidate build cache on forum post change
+ADD "https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224" /dev/null
 
 # Install Required packages
 RUN apt-get update && \
-    apt-get -y --allow-unauthenticated install --no-install-recommends python3 python3-pip eject sdparm gddrescue abcde eyed3 ffmpeg flac lame mkcue speex vorbis-tools vorbisgain id3 id3v2 && \
-    pip3 install docopt flask waitress && \
-    apt-get -y autoremove
+    apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    eject \
+    sdparm \
+    gddrescue \
+    abcde \
+    eyed3 \
+    ffmpeg \
+    flac \
+    lame \
+    mkcue \
+    speex \
+    vorbis-tools \
+    vorbisgain \
+    id3 \
+    id3v2 && \
+    pip3 install --no-cache-dir docopt flask waitress && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
- # Disable SSH
+# Move Files, set permissions and install makemkv
+COPY root/ /
+COPY manual-build/install/ /install
+RUN chmod +x /etc/my_init.d/*.sh && \
+    chmod -R 777 /tmp && \
+    chmod 775 /install && \
+    /install/install.sh && \
+    rm -rf /install
+
+# Disable SSH
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-
-# invalidate build cache on forum post change
-ADD "https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224" latest_post
-
-# MakeMKV setup by https://github.com/tianon
-RUN chmod +x /install/install.sh && sleep 1 && \
-    /install/install.sh
-
-# Clean up temp files
-RUN rm -rf \
-    	/tmp/* \
-    	/var/lib/apt/lists/* \
-    	/var/tmp/* \
-        /install/* \

--- a/manual-build/Dockerfile
+++ b/manual-build/Dockerfile
@@ -49,6 +49,7 @@ COPY manual-build/install/ /install
 RUN chmod +x /etc/my_init.d/*.sh && \
     chmod -R 777 /tmp && \
     chmod 775 /install && \
+    chmod +x /install/install.sh && \
     /install/install.sh && \
     rm -rf /install
 

--- a/manual-build/Dockerfile
+++ b/manual-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:focal-1.0.0
-MAINTAINER rix1337
+LABEL maintainer="rix1337"
 
 # Set correct environment variables
 ENV HOME /root

--- a/manual-build/Dockerfile
+++ b/manual-build/Dockerfile
@@ -16,9 +16,6 @@ RUN usermod -u 99 nobody && \
     usermod -d /home nobody && \
     chown nobody:users /home -R
 
-# Invalidate build cache on forum post change
-ADD "https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224" /dev/null
-
 # Install Required packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -42,6 +39,9 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Invalidate build cache on forum post change
+ADD "https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224" /dev/null
 
 # Move Files, set permissions and install makemkv
 COPY root/ /

--- a/manual-build/install/install.sh
+++ b/manual-build/install/install.sh
@@ -7,33 +7,33 @@
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the 
+# and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in 
-# all copies or substantial portions of the Software. 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL 
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
 # Auto-grab latest version
 {
 	MAKEMKV_VERSION="$(
-		curl -fsSL 'https://makemkv.com/download/' \
-			| grep -oE 'makemkv-sha-[0-9.]+.txt' \
-			| sed -r 's!^makemkv-sha-|[.]txt$!!g'
+		curl -fsSL 'https://makemkv.com/download/' |
+			grep -oE 'makemkv-sha-[0-9.]+.txt' |
+			sed -r 's!^makemkv-sha-|[.]txt$!!g'
 	)"
 	[ -n "$version" ]
 } || {
 	url="$(
-		curl -fsSL 'https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224' \
-			| grep -oE 'href="https?://[^"]+/makemkv-bin-[^"]+.tar.gz"' \
-			| cut -d'"' -f2
+		curl -fsSL 'https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224' |
+			grep -oE 'href="https?://[^"]+/makemkv-bin-[^"]+.tar.gz"' |
+			cut -d'"' -f2
 	)"
 	[ -n "$url" ]
 	MAKEMKV_VERSION="$(basename "$url" | sed -r 's!^makemkv-bin-|[.]tar[.]gz$!!g')"
@@ -84,14 +84,14 @@ for ball in makemkv-oss makemkv-bin; do
 done
 
 rm sha256sums.txt
-apt-mark auto '.*' > /dev/null
+apt-mark auto '.*' >/dev/null
 [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark
-find /usr/local -type f -executable -exec ldd '{}' ';' \
-	| awk '/=>/ { print $(NF-1) }' \
-	| sort -u \
-	| xargs -r dpkg-query --search \
-	| cut -d: -f1 \
-	| sort -u \
-	| xargs -r apt-mark manual \
+find /usr/local -type f -executable -exec ldd '{}' ';' |
+	awk '/=>/ { print $(NF-1) }' |
+	sort -u |
+	xargs -r dpkg-query --search |
+	cut -d: -f1 |
+	sort -u |
+	xargs -r apt-mark manual
 
 apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false

--- a/root/etc/my_init.d/ripper.sh
+++ b/root/etc/my_init.d/ripper.sh
@@ -2,6 +2,8 @@
 
 echo "Using this daily? Please sponsor me at https://github.com/sponsors/rix1337 - any amount counts!"
 
+mkdir -p /config
+
 # copy default script
 if [[ ! -f /config/ripper.sh ]]; then
     cp /ripper/ripper.sh /config/ripper.sh

--- a/root/etc/my_init.d/ripper.sh
+++ b/root/etc/my_init.d/ripper.sh
@@ -4,13 +4,13 @@ echo "Using this daily? Please sponsor me at https://github.com/sponsors/rix1337
 
 # copy default script
 if [[ ! -f /config/ripper.sh ]]; then
- cp /ripper/ripper.sh /config/ripper.sh
+    cp /ripper/ripper.sh /config/ripper.sh
 fi
 
 # copy default settings
-if [[ ! -f /config/settings.conf ]] && [[  ! -f /config/enter-your-key-then-rename-to.settings.conf ]]; then
- cp -f /ripper/settings.conf /config/
- mv /config/settings.conf /config/enter-your-key-then-rename-to.settings.conf 
+if [[ ! -f /config/settings.conf ]] && [[ ! -f /config/enter-your-key-then-rename-to.settings.conf ]]; then
+    cp -f /ripper/settings.conf /config/
+    mv /config/settings.conf /config/enter-your-key-then-rename-to.settings.conf
 fi
 
 # fetching MakeMKV beta key
@@ -18,20 +18,20 @@ KEY=$(curl --silent 'https://forum.makemkv.com/forum/viewtopic.php?f=5&t=1053' |
 
 # move settings.conf, if found
 mkdir -p /root/.MakeMKV
-if [[ -f  /config/settings.conf ]]; then
- echo "Found settings.conf. Replacing beta key file."
- cp -f  /config/settings.conf /root/.MakeMKV/
+if [[ -f /config/settings.conf ]]; then
+    echo "Found settings.conf. Replacing beta key file."
+    cp -f /config/settings.conf /root/.MakeMKV/
 elif [ -n $KEY ]; then
- echo "Using MakeMKV beta key: $KEY"
- echo app_Key = "\"$KEY"\" > /root/.MakeMKV/settings.conf
+    echo "Using MakeMKV beta key: $KEY"
+    echo app_Key = "\"$KEY"\" >/root/.MakeMKV/settings.conf
 fi
 
 makemkvcon reg
 
 # move abcde.conf, if found
-if [[ -f  /config/abcde.conf ]]; then
- echo "Found abcde.conf."
- cp -f  /config/abcde.conf /ripper/abcde.conf
+if [[ -f /config/abcde.conf ]]; then
+    echo "Found abcde.conf."
+    cp -f /config/abcde.conf /ripper/abcde.conf
 fi
 
 # permissions

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -50,11 +50,22 @@ check_disc() {
 
     for (( i=0; i<${#DRIVE_TYPES[@]}; i++ )); do
         TYPE=${DRIVE_TYPES[$i]}
+        echo $TYPE
+        echo $DRIVE_TYPES
         PATTERN=${DRIVE_PATTERNS[$i]}
+        echo $PATTERN
+        echo $DRIVE_PATTERNS
         MATCH=$(echo $INFO | grep -o "$PATTERN")
+         echo $MATCH
+         echo $PATTERN
         if [[ -n "$MATCH" ]]; then
             declare "$TYPE=$MATCH"
+            # debug echo to see what is being declared
+            echo $TYPE
+            echo $MATCH
             EXPECTED+="$MATCH"
+            echo $EXPECTED
+            
         fi
     done
 

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -276,25 +276,48 @@ launcher_function() {
    while true; do
       cleanup_tmp_files
       check_disc
-      if [ "$BAD_RESPONSE" -lt "$BAD_THRESHOLD" ]; then
-         if [[ "$JUSTMAKEISO" == "true" ]]; then
-            printf "%s : JustMakeISO is enabled. Saving ISO.\n" "$(date "+%d.%m.%Y %T")"
-            debug_log "JustMakeISO is enabled. Saving ISO."
-            handle_data_disc "$INFO"
-         else
-            process_disc_type
-            if [[ "$ALSOMAKEISO" == "true" ]]; then
-               printf "%s : AlsoMakeISO is enabled. Saving ISO.\n" "$(date "+%d.%m.%Y %T")"
-               debug_log "AlsoMakeISO is enabled. Saving ISO."
+      case "$DISC_TYPE" in
+      "empty")
+         printf "%s : No disc inserted, checking again in 1 minute.\n" "$(date "+%d.%m.%Y %T")"
+         debug_log "No disc inserted, checking again in 1 minute."
+         ;;
+      "open")
+         printf "%s : Disc tray open, checking again in 1 minute.\n" "$(date "+%d.%m.%Y %T")"
+         debug_log "Disc tray open, checking again in 1 minute."
+         ;;
+      "loading")
+         printf "%s : Disc loading, checking again in 1 minute.\n" "$(date "+%d.%m.%Y %T")"
+         debug_log "Disc loading, checking again in 1 minute."
+         ;;
+      *)
+         if [ "$BAD_RESPONSE" -lt "$BAD_THRESHOLD" ]; then
+            case "$JUSTMAKEISO" in
+            "true")
+               printf "%s : JustMakeISO is enabled. Saving ISO.\n" "$(date "+%d.%m.%Y %T")"
+               debug_log "JustMakeISO is enabled. Saving ISO."
                handle_data_disc "$INFO"
-            fi
+               ejectdisc
+               ;;
+            *)
+               process_disc_type
+               case "$ALSOMAKEISO" in
+               "true")
+                  printf "%s : AlsoMakeISO is enabled. Saving ISO.\n" "$(date "+%d.%m.%Y %T")"
+                  debug_log "AlsoMakeISO is enabled. Saving ISO."
+                  handle_data_disc "$INFO"
+                  ejectdisc
+                  ;;
+               esac
+               ;;
+            esac
+         else
+            printf "%s : Too many bad responses, checking stopped.\n" "$(date "+%d.%m.%Y %T")"
+            debug_log "Too many bad responses, checking stopped."
+            ejectdisc
+            exit 1
          fi
-      else
-         printf "%s : Too many bad responses, checking stopped.\n" "$(date "+%d.%m.%Y %T")"
-         debug_log "Too many bad responses, checking stopped."
-         exit 1
-      fi
-      ejectdisc
+         ;;
+      esac
       sleep 1m # Wait 1 minute before checking for a new disc
    done
 }

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -191,6 +191,20 @@ handle_data_disc() {
    debug_log "Changed owner and permissions for: $STORAGE_DATA"
 }
 
+move_to_finished() {
+    local src_path="$1"
+    local dst_root="$2"
+    local disc_label="$3"
+    if [ "$SEPARATERAWFINISH" = 'true' ]; then
+        local finish_path="${dst_root}/finished/${disc_label}"
+        debug_log "Moving ${src_path} to finished directory: ${finish_path}"
+        mkdir -p "${dst_root}/finished"
+        mv -v "${src_path}" "${finish_path}"
+        chown -R nobody:users "${dst_root}" && chmod -R g+rw "${dst_root}"
+    fi
+}
+
+
 ejectdisc() {
    if [[ "$EJECTENABLED" == "true" ]]; then
       if eject -v "$DRIVE" &>/dev/null; then

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -20,6 +20,7 @@ printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 6
 : "${SEPARATERAWFINISH:=false}"
 : "${ALSOMAKEISO:=false}"
 : "${TIMESTAMPPREFIX:=false}"
+: "${MINIMUMLENGTH:=600}"
 # Print the values of configuration options if DEBUG is enabled
 if [[ "$DEBUG" == true ]]; then
    printf "SEPARATERAWFINISH: %s\n" "$SEPARATERAWFINISH"
@@ -35,6 +36,7 @@ if [[ "$DEBUG" == true ]]; then
    printf "BAD_THRESHOLD: %s\n" "$BAD_THRESHOLD"
    printf "DEBUG: %s\n" "$DEBUG"
    printf "DEBUGTOWEB: %s\n" "$DEBUGTOWEB"
+   printf "MINIMUMLENGTH: %s\n" "$MINIMUMLENGTH"
 fi
 
 BAD_RESPONSE=0
@@ -130,7 +132,7 @@ handle_bd_disc() {
    else
       printf "%s : BluRay detected: Saving MKV\n" "$(date "+%d.%m.%Y %T")"
       debug_log "Saving BluRay as MKV."
-      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
+      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength="$MINIMUMLENGTH" mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
    fi
 
    move_to_finished "$bd_path" "$STORAGE_BD"
@@ -154,7 +156,7 @@ handle_dvd_disc() {
    else
       printf "%s : DVD detected: Saving MKV\n" "$(date "+%d.%m.%Y %T")"
       debug_log "Saving DVD as MKV."
-      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
+      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength="$MINIMUMLENGTH" mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
    fi
 
    move_to_finished "$dvd_path" "$STORAGE_DVD"

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -17,187 +17,189 @@ printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 6
 : "${BAD_THRESHOLD:=5}"
 : "${DEBUG:=false}"
 : "${DEBUGTOWEB:=false}"
-# Print the values of configuration options
-printf "SEPARATERAWFINISH: %s\n" "$SEPARATERAWFINISH"
-printf "EJECTENABLED: %s\n" "$EJECTENABLED"
-printf "JUSTMAKEISO: %s\n" "$JUSTMAKEISO"
-printf "STORAGE_CD: %s\n" "$STORAGE_CD"
-printf "STORAGE_DATA: %s\n" "$STORAGE_DATA"
-printf "STORAGE_DVD: %s\n" "$STORAGE_DVD"
-printf "STORAGE_BD: %s\n" "$STORAGE_BD"
-printf "DRIVE: %s\n" "$DRIVE"
-printf "BAD_THRESHOLD: %s\n" "$BAD_THRESHOLD"
-printf "DEBUG: %s\n" "$DEBUG"
-printf "DEBUGTOWEB: %s\n" "$DEBUGTOWEB"
+# Print the values of configuration options if DEBUG is enabled
+if [[ "$DEBUG" == true ]]; then
+   printf "SEPARATERAWFINISH: %s\n" "$SEPARATERAWFINISH"
+   printf "EJECTENABLED: %s\n" "$EJECTENABLED"
+   printf "JUSTMAKEISO: %s\n" "$JUSTMAKEISO"
+   printf "STORAGE_CD: %s\n" "$STORAGE_CD"
+   printf "STORAGE_DATA: %s\n" "$STORAGE_DATA"
+   printf "STORAGE_DVD: %s\n" "$STORAGE_DVD"
+   printf "STORAGE_BD: %s\n" "$STORAGE_BD"
+   printf "DRIVE: %s\n" "$DRIVE"
+   printf "BAD_THRESHOLD: %s\n" "$BAD_THRESHOLD"
+   printf "DEBUG: %s\n" "$DEBUG"
+   printf "DEBUGTOWEB: %s\n" "$DEBUGTOWEB"
+fi
 
 BAD_RESPONSE=0
 DISC_TYPE=""
 # Define the drive types and patterns to match against the output of makemkvcon
 declare -A DRIVE_TYPE_PATTERNS=(
-    [empty]='DRV:0,0,999,0,"'
-    [open]='DRV:0,1,999,0,"'
-    [loading]='DRV:0,3,999,0,"'
-    [bd1]='DRV:0,2,999,12,"'
-    [bd2]='DRV:0,2,999,28,"'
-    [dvd]='DRV:0,2,999,1,"'
-    [cd1]='DRV:0,2,999,0,"'
-    [cd2]='","","'$DRIVE'"'
+   [empty]='DRV:0,0,999,0,"'
+   [open]='DRV:0,1,999,0,"'
+   [loading]='DRV:0,3,999,0,"'
+   [bd1]='DRV:0,2,999,12,"'
+   [bd2]='DRV:0,2,999,28,"'
+   [dvd]='DRV:0,2,999,1,"'
+   [cd1]='DRV:0,2,999,0,"'
+   [cd2]='","","'$DRIVE'"'
 )
 
 debug_log() {
-  if [[ "$DEBUG" == true ]]; then
-    echo "[DEBUG] $(date "+%d.%m.%Y %T"): $1"
-  fi
-  if [[ "$DEBUGTOWEB" == true ]]; then
-    echo "$(date "+%d.%m.%Y %T"): $1" >> "$LOGFILE"
-  fi
+   if [[ "$DEBUG" == true ]]; then
+      echo "[DEBUG] $(date "+%d.%m.%Y %T"): $1"
+   fi
+   if [[ "$DEBUGTOWEB" == true ]]; then
+      echo "$(date "+%d.%m.%Y %T"): $1" >>"$LOGFILE"
+   fi
 }
 
 cleanup_tmp_files() {
-  debug_log "Cleaning up temporary files."
-  local tmp_dir="/tmp"
-  cd "$tmp_dir" || exit
-  rm -rf ./*.tmp 2>/dev/null
-  cd - || exit
-  debug_log "Temporary file cleanup completed."
+   debug_log "Cleaning up temporary files."
+   local tmp_dir="/tmp"
+   cd "$tmp_dir" || exit
+   rm -rf ./*.tmp 2>/dev/null
+   cd - || exit
+   debug_log "Temporary file cleanup completed."
 }
 
 check_disc() {
-    debug_log "Checking disc."
-    INFO=$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)
-    debug_log "INFO: $INFO"
-    DISC_TYPE=""  # Clear previous disc type value
+   debug_log "Checking disc."
+   INFO=$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)
+   debug_log "INFO: $INFO"
+   DISC_TYPE="" # Clear previous disc type value
 
-    for TYPE in "${!DRIVE_TYPE_PATTERNS[@]}"; do
-        PATTERN=${DRIVE_TYPE_PATTERNS[$TYPE]}
-        if echo "$INFO" | grep -q "$PATTERN"; then
-            DISC_TYPE=$TYPE
-            debug_log "Detected disc type: $DISC_TYPE"
-            break
-        fi
-    done
+   for TYPE in "${!DRIVE_TYPE_PATTERNS[@]}"; do
+      PATTERN=${DRIVE_TYPE_PATTERNS[$TYPE]}
+      if echo "$INFO" | grep -q "$PATTERN"; then
+         DISC_TYPE=$TYPE
+         debug_log "Detected disc type: $DISC_TYPE"
+         break
+      fi
+   done
 
-    if [[ -z "$DISC_TYPE" ]]; then
-        echo "$(date "+%d.%m.%Y %T") : Unexpected makemkvcon output: $INFO"
-        debug_log "Unexpected makemkvcon output."
-        (( BAD_RESPONSE++ ))
-    else
-        BAD_RESPONSE=0
-    fi
+   if [[ -z "$DISC_TYPE" ]]; then
+      echo "$(date "+%d.%m.%Y %T") : Unexpected makemkvcon output: $INFO"
+      debug_log "Unexpected makemkvcon output."
+      ((BAD_RESPONSE++))
+   else
+      BAD_RESPONSE=0
+   fi
 }
 
 handle_bd_disc() {
-  local disc_info="$1"
-  debug_log "Handling BluRay disc."
-  local disc_label="$(echo "$disc_info" | grep -o -P '(?<=",").*(?=",")')"
-  local bd_path="$STORAGE_BD/$disc_label"
-  local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
-  debug_log "Disc label: $disc_label, Disc number: $disc_number, BD path: $bd_path"
-  mkdir -p "$bd_path"
-  local alt_rip="${RIPPER_DIR}/BLURAYrip.sh"
-  if [[ -f $alt_rip && -x $alt_rip ]]; then
-    echo "$(date "+%d.%m.%Y %T") : BluRay detected: Executing $alt_rip"
-    debug_log "Executing alternative BluRay rip script."
-    $alt_rip "$disc_number" "$bd_path" "$LOGFILE"
-  else
-    echo "$(date "+%d.%m.%Y %T") : BluRay detected: Saving MKV"
-    debug_log "Saving BluRay as MKV."
-    makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
-  fi
-  if [ "$SEPARATERAWFINISH" = 'true' ]; then
-    local bd_finish="$STORAGE_BD/finished/"
-    debug_log "Moving BluRay rip to finished directory: $bd_finish"
-    mv -v "$bd_path" "$bd_finish"
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
-  ejectdisc
-  debug_log "Ejecting BluRay disc."
-  chown -R nobody:users "$STORAGE_BD" && chmod -R g+rw "$STORAGE_BD"
-  debug_log "Changed owner and permissions for: $STORAGE_BD"
+   local disc_info="$1"
+   debug_log "Handling BluRay disc."
+   local disc_label="$(echo "$disc_info" | grep -o -P '(?<=",").*(?=",")')"
+   local bd_path="$STORAGE_BD/$disc_label"
+   local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
+   debug_log "Disc label: $disc_label, Disc number: $disc_number, BD path: $bd_path"
+   mkdir -p "$bd_path"
+   local alt_rip="${RIPPER_DIR}/BLURAYrip.sh"
+   if [[ -f $alt_rip && -x $alt_rip ]]; then
+      echo "$(date "+%d.%m.%Y %T") : BluRay detected: Executing $alt_rip"
+      debug_log "Executing alternative BluRay rip script."
+      $alt_rip "$disc_number" "$bd_path" "$LOGFILE"
+   else
+      echo "$(date "+%d.%m.%Y %T") : BluRay detected: Saving MKV"
+      debug_log "Saving BluRay as MKV."
+      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
+   fi
+   if [ "$SEPARATERAWFINISH" = 'true' ]; then
+      local bd_finish="$STORAGE_BD/finished/"
+      debug_log "Moving BluRay rip to finished directory: $bd_finish"
+      mv -v "$bd_path" "$bd_finish"
+   fi
+   echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+   ejectdisc
+   debug_log "Ejecting BluRay disc."
+   chown -R nobody:users "$STORAGE_BD" && chmod -R g+rw "$STORAGE_BD"
+   debug_log "Changed owner and permissions for: $STORAGE_BD"
 }
 
 handle_dvd_disc() {
-  local disc_info="$1"
-  debug_log "Handling DVD disc."
-  local disc_label="$(echo "$disc_info" | grep -o -P '(?<=",").*(?=",")')"
-  local dvd_path="$STORAGE_DVD/$disc_label"
-  local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
-  debug_log "Disc label: $disc_label, Disc number: $disc_number, DVD path: $dvd_path"
-  mkdir -p "$dvd_path"
-  local alt_rip="${RIPPER_DIR}/DVDrip.sh"
-  if [[ -f $alt_rip && -x $alt_rip ]]; then
-    echo "$(date "+%d.%m.%Y %T") : DVD detected: Executing $alt_rip"
-    debug_log "Executing alternative DVD rip script."
-    $alt_rip "$disc_number" "$dvd_path" "$LOGFILE"
-  else
-    echo "$(date "+%d.%m.%Y %T") : DVD detected: Saving MKV"
-    debug_log "Saving DVD as MKV."
-    makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
-  fi
-  if [ "$SEPARATERAWFINISH" = 'true' ]; then
-    local dvd_finish="$STORAGE_DVD/finished/"
-    debug_log "Moving DVD rip to finished directory: $dvd_finish"
-    mv -v "$dvd_path" "$dvd_finish"
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
-  ejectdisc
-  debug_log "Ejecting DVD disc."
-  chown -R nobody:users "$STORAGE_DVD" && chmod -R g+rw "$STORAGE_DVD"
-  debug_log "Changed owner and permissions for: $STORAGE_DVD"
+   local disc_info="$1"
+   debug_log "Handling DVD disc."
+   local disc_label="$(echo "$disc_info" | grep -o -P '(?<=",").*(?=",")')"
+   local dvd_path="$STORAGE_DVD/$disc_label"
+   local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
+   debug_log "Disc label: $disc_label, Disc number: $disc_number, DVD path: $dvd_path"
+   mkdir -p "$dvd_path"
+   local alt_rip="${RIPPER_DIR}/DVDrip.sh"
+   if [[ -f $alt_rip && -x $alt_rip ]]; then
+      echo "$(date "+%d.%m.%Y %T") : DVD detected: Executing $alt_rip"
+      debug_log "Executing alternative DVD rip script."
+      $alt_rip "$disc_number" "$dvd_path" "$LOGFILE"
+   else
+      echo "$(date "+%d.%m.%Y %T") : DVD detected: Saving MKV"
+      debug_log "Saving DVD as MKV."
+      makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
+   fi
+   if [ "$SEPARATERAWFINISH" = 'true' ]; then
+      local dvd_finish="$STORAGE_DVD/finished/"
+      debug_log "Moving DVD rip to finished directory: $dvd_finish"
+      mv -v "$dvd_path" "$dvd_finish"
+   fi
+   echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+   ejectdisc
+   debug_log "Ejecting DVD disc."
+   chown -R nobody:users "$STORAGE_DVD" && chmod -R g+rw "$STORAGE_DVD"
+   debug_log "Changed owner and permissions for: $STORAGE_DVD"
 }
 
 handle_cd_disc() {
-  local disc_info="$1"
-  debug_log "Handling CD disc."
-  local alt_rip="${RIPPER_DIR}/CDrip.sh"
-  if [[ -f $alt_rip && -x $alt_rip ]]; then
-    echo "$(date "+%d.%m.%Y %T") : CD detected: Executing $alt_rip"
-    debug_log "Executing alternative CD rip script."
-    $alt_rip "$DRIVE" "$STORAGE_CD" "$LOGFILE"
-  else
-    echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC"
-    debug_log "Saving CD as MP3 and FLAC."
-    /usr/bin/abcde -d "$DRIVE" -c /ripper/abcde.conf -N -x -l >>"$LOGFILE" 2>&1
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
-  ejectdisc
-  debug_log "Ejecting CD disc."
-  chown -R nobody:users "$STORAGE_CD" && chmod -R g+rw "$STORAGE_CD"
-  debug_log "Changed owner and permissions for: $STORAGE_CD"
+   local disc_info="$1"
+   debug_log "Handling CD disc."
+   local alt_rip="${RIPPER_DIR}/CDrip.sh"
+   if [[ -f $alt_rip && -x $alt_rip ]]; then
+      echo "$(date "+%d.%m.%Y %T") : CD detected: Executing $alt_rip"
+      debug_log "Executing alternative CD rip script."
+      $alt_rip "$DRIVE" "$STORAGE_CD" "$LOGFILE"
+   else
+      echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC"
+      debug_log "Saving CD as MP3 and FLAC."
+      /usr/bin/abcde -d "$DRIVE" -c /ripper/abcde.conf -N -x -l >>"$LOGFILE" 2>&1
+   fi
+   echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+   ejectdisc
+   debug_log "Ejecting CD disc."
+   chown -R nobody:users "$STORAGE_CD" && chmod -R g+rw "$STORAGE_CD"
+   debug_log "Changed owner and permissions for: $STORAGE_CD"
 }
 
 handle_data_disc() {
-  local disc_info="$1"
-  debug_log "Handling data disc."
-  local disc_label="$(echo "$disc_info" | grep "$DRIVE" | grep -o -P '(?<=",").*(?=",")')"
-  local iso_path="$STORAGE_DATA/$disc_label/${disc_label}.iso"
-  debug_log "Disc label: $disc_label, ISO path: $iso_path"
-  mkdir -p "$STORAGE_DATA/$disc_label"
-  local alt_rip="${RIPPER_DIR}/DATArip.sh"
-  if [[ -f $alt_rip && -x $alt_rip ]]; then
-    echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Executing $alt_rip"
-    debug_log "Executing alternative DATA disc rip script."
-    $alt_rip "$DRIVE" "$iso_path" "$LOGFILE"
-  else
-    echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Saving ISO"
-    debug_log "Saving data-disc as ISO."
-    ddrescue "$DRIVE" "$iso_path" >>"$LOGFILE" 2>&1
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
-  ejectdisc
-  debug_log "Ejecting data disc."
-  chown -R nobody:users "$STORAGE_DATA" && chmod -R g+rw "$STORAGE_DATA"
-  debug_log "Changed owner and permissions for: $STORAGE_DATA"
+   local disc_info="$1"
+   debug_log "Handling data disc."
+   local disc_label="$(echo "$disc_info" | grep "$DRIVE" | grep -o -P '(?<=",").*(?=",")')"
+   local iso_path="$STORAGE_DATA/$disc_label/${disc_label}.iso"
+   debug_log "Disc label: $disc_label, ISO path: $iso_path"
+   mkdir -p "$STORAGE_DATA/$disc_label"
+   local alt_rip="${RIPPER_DIR}/DATArip.sh"
+   if [[ -f $alt_rip && -x $alt_rip ]]; then
+      echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Executing $alt_rip"
+      debug_log "Executing alternative DATA disc rip script."
+      $alt_rip "$DRIVE" "$iso_path" "$LOGFILE"
+   else
+      echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Saving ISO"
+      debug_log "Saving data-disc as ISO."
+      ddrescue "$DRIVE" "$iso_path" >>"$LOGFILE" 2>&1
+   fi
+   echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+   ejectdisc
+   debug_log "Ejecting data disc."
+   chown -R nobody:users "$STORAGE_DATA" && chmod -R g+rw "$STORAGE_DATA"
+   debug_log "Changed owner and permissions for: $STORAGE_DATA"
 }
 
 ejectdisc() {
-  debug_log "Ejecting disc from $DRIVE."
-  if [[ "$EJECTENABLED" == "true" ]]; then
+   debug_log "Ejecting disc from $DRIVE."
+   if [[ "$EJECTENABLED" == "true" ]]; then
       if eject -v "$DRIVE" &>/dev/null; then
          printf "Ejecting disc Succeeded\n"
          debug_log "Ejecting disc succeeded."
       else
-         printf "%s : Ejecting disc Failed. Attempting Alternative Method.\n" "$(date "+%d.%m.%Y %T")" >> "$LOGFILE"
+         printf "%s : Ejecting disc Failed. Attempting Alternative Method.\n" "$(date "+%d.%m.%Y %T")" >>"$LOGFILE"
          debug_log "Ejecting disc failed. Attempting alternative method."
          sleep 2
          sdparm --command=unlock "$DRIVE"
@@ -211,50 +213,56 @@ ejectdisc() {
 }
 
 process_disc_type() {
-  debug_log "Processing disc type."
-  case "$DISC_TYPE" in
-    "empty")
+   debug_log "Processing disc type."
+   case "$DISC_TYPE" in
+   "empty")
       echo "$(date "+%d.%m.%Y %T") : No disc inserted."
       debug_log "No disc inserted."
       ;;
-    "open")
+   "open")
       echo "$(date "+%d.%m.%Y %T") : Disc tray open."
       debug_log "Disc tray open."
       ;;
-    "loading")
+   "loading")
       echo "$(date "+%d.%m.%Y %T") : Disc loading."
       debug_log "Disc loading."
       ;;
-    "bd1"|"bd2")
+   "bd1" | "bd2")
       handle_bd_disc "$INFO"
       ;;
-    "dvd")
+   "dvd")
       handle_dvd_disc "$INFO"
       ;;
-    "cd1"|"cd2")
+   "cd1" | "cd2")
       handle_cd_disc "$INFO"
       ;;
-    *)
+   *)
       echo "$(date "+%d.%m.%Y %T") : Disc type not recognized."
       debug_log "Disc type not recognized."
       ;;
-  esac
+   esac
 }
 
 launcher_function() {
-  debug_log "Starting main function."
-  while true; do
-    cleanup_tmp_files
-    check_disc 
-    if [ "$BAD_RESPONSE" -lt "$BAD_THRESHOLD" ]; then
-        process_disc_type
-    else
-        echo "$(date "+%d.%m.%Y %T") : Too many bad responses, checking stopped."
-        debug_log "Too many bad responses, checking stopped."
-        exit 1
-    fi
-    sleep 1m
-  done
+   debug_log "Starting main function."
+   while true; do
+      cleanup_tmp_files
+      check_disc
+      if [ "$BAD_RESPONSE" -lt "$BAD_THRESHOLD" ]; then
+         if [[ "$JUSTMAKEISO" == "true" ]]; then
+            echo "$(date "+%d.%m.%Y %T") : JustMakeISO is enabled. Saving ISO."
+            debug_log "JustMakeISO is enabled. Saving ISO."
+            handle_data_disc "$INFO"
+         else
+            process_disc_type
+         fi
+      else
+         echo "$(date "+%d.%m.%Y %T") : Too many bad responses, checking stopped."
+         debug_log "Too many bad responses, checking stopped."
+         exit 1
+      fi
+      sleep 1m
+   done
 }
 
 debug_log "Script start."

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -70,13 +70,13 @@ while true; do
    cleanup_tmp_files
    check_disc
    if (( BAD_RESPONSE >= BAD_THRESHOLD )); then
-      echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disk and aborting"
+      echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disc and aborting"
       makemkvcon -r --cache=1 info disc:9999
-      ejectDisk
+      ejectdisc
    fi
-   # get disk info through makemkv and pass output to INFO
+   # get disc info through makemkv and pass output to INFO
    INFO=$"$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)"
-   # check INFO for optical disk
+   # check INFO for optical disc
    EMPTY=$(echo $INFO | grep -o 'DRV:0,0,999,0,"')
    OPEN=$(echo $INFO | grep -o 'DRV:0,1,999,0,"')
    LOADING=$(echo $INFO | grep -o 'DRV:0,3,999,0,"')
@@ -95,24 +95,24 @@ while true; do
       let BAD_RESPONSE=0
    fi
    if (($BAD_RESPONSE >= $BAD_THRESHOLD)); then
-      echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disk and aborting"
+      echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disc and aborting"
       # Run makemkvcon once more with full output, to potentially aid in debugging
       makemkvcon -r --cache=1 info disc:9999
-      ejectDisk
+      ejectdisc
    fi
    # if [ $EMPTY = 'DRV:0,0,999,0,"' ]; then
    #  echo "$(date "+%d.%m.%Y %T") : No Disc"; &>/dev/null
    # fi
    if [ "$OPEN" = 'DRV:0,1,999,0,"' ]; then
-      echo "$(date "+%d.%m.%Y %T") : Disk tray open"
+      echo "$(date "+%d.%m.%Y %T") : disc tray open"
    fi
    if [ "$LOADING" = 'DRV:0,3,999,0,"' ]; then
       echo "$(date "+%d.%m.%Y %T") : Disc still loading"
    fi
 
    if [ "$BD1" = 'DRV:0,2,999,12,"' ] || [ "$BD2" = 'DRV:0,2,999,28,"' ]; then
-      DISKLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
-      BDPATH="$STORAGE_BD"/"$DISKLABEL"
+      discLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
+      BDPATH="$STORAGE_BD"/"$discLABEL"
       BLURAYNUM=$(echo $INFO | grep $DRIVE | cut -c5)
       mkdir -p "$BDPATH"
       ALT_RIP="${RIPPER_DIR}/BLURAYrip.sh"
@@ -128,15 +128,15 @@ while true; do
          BDFINISH="$STORAGE_BD"/finished/
          mv -v "$BDPATH" "$BDFINISH"
       fi
-      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-      ejectDisk
+      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+      ejectdisc
       # permissions
       chown -R nobody:users "$STORAGE_BD" && chmod -R g+rw "$STORAGE_BD"
    fi
 
    if [ "$DVD" = 'DRV:0,2,999,1,"' ]; then
-      DISKLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
-      DVDPATH="$STORAGE_DVD"/"$DISKLABEL"
+      discLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
+      DVDPATH="$STORAGE_DVD"/"$discLABEL"
       DVDNUM=$(echo $INFO | grep $DRIVE | cut -c5)
       mkdir -p "$DVDPATH"
       ALT_RIP="${RIPPER_DIR}/DVDrip.sh"
@@ -152,8 +152,8 @@ while true; do
          DVDFINISH="$STORAGE_DVD"/finished/
          mv -v "$DVDPATH" "$DVDFINISH"
       fi
-      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-      ejectDisk
+      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+      ejectdisc
       # permissions
       chown -R nobody:users "$STORAGE_DVD" && chmod -R g+rw "$STORAGE_DVD"
    fi
@@ -169,25 +169,25 @@ while true; do
             echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC"
             /usr/bin/abcde -d "$DRIVE" -c /ripper/abcde.conf -N -x -l >>$LOGFILE 2>&1
          fi
-         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-         ejectDisk
+         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+         ejectdisc
          # permissions
          chown -R nobody:users "$STORAGE_CD" && chmod -R g+rw "$STORAGE_CD"
       else
-         DISKLABEL=$(echo $INFO | grep $DRIVE | grep -o -P '(?<=",").*(?=",")')
-         ISOPATH="$STORAGE_DATA"/"$DISKLABEL"/"$DISKLABEL".iso
-         mkdir -p "$STORAGE_DATA"/"$DISKLABEL"
+         discLABEL=$(echo $INFO | grep $DRIVE | grep -o -P '(?<=",").*(?=",")')
+         ISOPATH="$STORAGE_DATA"/"$discLABEL"/"$discLABEL".iso
+         mkdir -p "$STORAGE_DATA"/"$discLABEL"
          ALT_RIP="${RIPPER_DIR}/DATArip.sh"
          if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
-            echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Executing $ALT_RIP"
+            echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Executing $ALT_RIP"
             $ALT_RIP "$DRIVE" "$ISOPATH" "$LOGFILE"
          else
             # ISO
-            echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Saving ISO"
+            echo "$(date "+%d.%m.%Y %T") : Data-disc detected: Saving ISO"
             ddrescue $DRIVE "$ISOPATH" >>$LOGFILE 2>&1
          fi
-         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-         ejectDisk
+         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting disc"
+         ejectdisc
          # permissions
          chown -R nobody:users "$STORAGE_DATA" && chmod -R g+rw "$STORAGE_DATA"
       fi
@@ -197,13 +197,13 @@ while true; do
 done
 
 
-# function to eject the disk - now with a lower-case function name
-ejectdisk() {
+# function to eject the disc - now with a lower-case function name
+ejectdisc() {
    if [[ "$EJECTENABLED" == "true" ]]; then
       if eject -v "$DRIVE" &>/dev/null; then
-         printf "Ejecting Disk Succeeded\n"
+         printf "Ejecting disc Succeeded\n"
       else
-         printf "%s : Ejecting Disk Failed. Attempting Alternative Method.\n" "$(date "+%d.%m.%Y %T")" >> "$LOGFILE"
+         printf "%s : Ejecting disc Failed. Attempting Alternative Method.\n" "$(date "+%d.%m.%Y %T")" >> "$LOGFILE"
          sleep 2
          sdparm --command=unlock "$DRIVE"
          sleep 1

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -111,7 +111,7 @@ handle_bd_disc() {
       makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
    fi
 
-   move_to_finished "$bd_path" "$STORAGE_BD" "$disc_label"
+   move_to_finished "$bd_path" "$STORAGE_BD"
 }
 
 handle_dvd_disc() {
@@ -134,7 +134,7 @@ handle_dvd_disc() {
       makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
    fi
 
-   move_to_finished "$dvd_path" "$STORAGE_DVD" "$disc_label"
+   move_to_finished "$dvd_path" "$STORAGE_DVD"
 }
 
 handle_cd_disc() {
@@ -182,15 +182,17 @@ handle_data_disc() {
 move_to_finished() {
    local src_path="$1"
    local dst_root="$2"
-   local disc_label="$3"
    if [ "$SEPARATERAWFINISH" = 'true' ]; then
-      local finish_path="${dst_root}/finished/${disc_label}"
+      local finish_path="${dst_root}/finished/"
+      mkdir -p "$finish_path"
+      local base_name=$(basename "$src_path")
+      finish_path+="$base_name"
       debug_log "Moving ${src_path} to finished directory: ${finish_path}"
-      mkdir -p "${dst_root}/finished"
-      mv -v "${src_path}" "${finish_path}"
-      chown -R nobody:users "${dst_root}" && chmod -R g+rw "${dst_root}"
+      mv -v "$src_path" "$finish_path"
+      chown -R nobody:users "$dst_root" && chmod -R g+rw "$dst_root"
+      debug_log "Moved $src_path to $finish_path"
    else
-      debug_log "Skipping move to finished directory as SEPARATERAWFINISH is false"
+      debug_log "SEPARATERAWFINISH is disabled, not moving $src_path"
    fi
 }
 

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -186,9 +186,12 @@ handle_data_disc() {
    local disc_info="$1"
    debug_log "Handling data disc."
    local disc_label="$(echo "$disc_info" | grep "$DRIVE" | grep -o -P '(?<=",").*(?=",")')"
-   local iso_path="$STORAGE_DATA/$disc_label/${disc_label}.iso"
+   local data_directory
+   data_directory=$(get_disc_directory "$STORAGE_DATA" "$disc_label" "$TIMESTAMPPREFIX")
+   local iso_filename="${disc_label}.iso"
+   local iso_path="${data_directory}/${iso_filename}"
    debug_log "Disc label: $disc_label, ISO path: $iso_path"
-   mkdir -p "$STORAGE_DATA/$disc_label"
+   mkdir -p "$data_directory"
    local alt_rip="${RIPPER_DIR}/DATArip.sh"
    if [[ -f $alt_rip && -x $alt_rip ]]; then
       printf "%s : Data-disc detected: Executing %s\n" "$(date "+%d.%m.%Y %T")" "$alt_rip"
@@ -205,6 +208,7 @@ handle_data_disc() {
    debug_log "Changed owner and permissions for: $STORAGE_DATA"
    JUST_MADE_ISO=true
 }
+
 
 move_to_finished() {
    local src_path="$1"

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -24,6 +24,7 @@ if [[ "$DEBUG" == true ]]; then
    printf "SEPARATERAWFINISH: %s\n" "$SEPARATERAWFINISH"
    printf "EJECTENABLED: %s\n" "$EJECTENABLED"
    printf "JUSTMAKEISO: %s\n" "$JUSTMAKEISO"
+   printf "ALSOMAKEISO: %s\n" "$ALSOMAKEISO"
    printf "STORAGE_CD: %s\n" "$STORAGE_CD"
    printf "STORAGE_DATA: %s\n" "$STORAGE_DATA"
    printf "STORAGE_DVD: %s\n" "$STORAGE_DVD"
@@ -32,7 +33,6 @@ if [[ "$DEBUG" == true ]]; then
    printf "BAD_THRESHOLD: %s\n" "$BAD_THRESHOLD"
    printf "DEBUG: %s\n" "$DEBUG"
    printf "DEBUGTOWEB: %s\n" "$DEBUGTOWEB"
-   printf "ALSOMAKEISO: %s\n" "$ALSOMAKEISO"
 fi
 
 BAD_RESPONSE=0
@@ -99,7 +99,7 @@ handle_bd_disc() {
    local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
    debug_log "Disc label: $disc_label, Disc number: $disc_number, BD path: $bd_path"
    mkdir -p "$bd_path"
-   
+
    local alt_rip="${RIPPER_DIR}/BLURAYrip.sh"
    if [[ -f $alt_rip && -x $alt_rip ]]; then
       printf "%s : BluRay detected: Executing %s\n" "$(date "+%d.%m.%Y %T")" "$alt_rip"
@@ -110,7 +110,7 @@ handle_bd_disc() {
       debug_log "Saving BluRay as MKV."
       makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$bd_path" >>"$LOGFILE" 2>&1
    fi
-   
+
    move_to_finished "$bd_path" "$STORAGE_BD" "$disc_label"
 }
 
@@ -122,7 +122,7 @@ handle_dvd_disc() {
    local disc_number="$(echo "$disc_info" | grep "$DRIVE" | cut -c5)"
    debug_log "Disc label: $disc_label, Disc number: $disc_number, DVD path: $dvd_path"
    mkdir -p "$dvd_path"
-   
+
    local alt_rip="${RIPPER_DIR}/DVDrip.sh"
    if [[ -f $alt_rip && -x $alt_rip ]]; then
       printf "%s : DVD detected: Executing %s\n" "$(date "+%d.%m.%Y %T")" "$alt_rip"
@@ -133,7 +133,7 @@ handle_dvd_disc() {
       debug_log "Saving DVD as MKV."
       makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$disc_number" all "$dvd_path" >>"$LOGFILE" 2>&1
    fi
-   
+
    move_to_finished "$dvd_path" "$STORAGE_DVD" "$disc_label"
 }
 
@@ -180,20 +180,19 @@ handle_data_disc() {
 }
 
 move_to_finished() {
-    local src_path="$1"
-    local dst_root="$2"
-    local disc_label="$3"
-    if [ "$SEPARATERAWFINISH" = 'true' ]; then
-        local finish_path="${dst_root}/finished/${disc_label}"
-        debug_log "Moving ${src_path} to finished directory: ${finish_path}"
-        mkdir -p "${dst_root}/finished"
-        mv -v "${src_path}" "${finish_path}"
-        chown -R nobody:users "${dst_root}" && chmod -R g+rw "${dst_root}"
-    else
+   local src_path="$1"
+   local dst_root="$2"
+   local disc_label="$3"
+   if [ "$SEPARATERAWFINISH" = 'true' ]; then
+      local finish_path="${dst_root}/finished/${disc_label}"
+      debug_log "Moving ${src_path} to finished directory: ${finish_path}"
+      mkdir -p "${dst_root}/finished"
+      mv -v "${src_path}" "${finish_path}"
+      chown -R nobody:users "${dst_root}" && chmod -R g+rw "${dst_root}"
+   else
       debug_log "Skipping move to finished directory as SEPARATERAWFINISH is false"
-    fi
+   fi
 }
-
 
 ejectdisc() {
    if [[ "$EJECTENABLED" == "true" ]]; then

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -9,16 +9,15 @@ echo "$(date "+%d.%m.%Y %T") : Starting Ripper. Optical Discs will be detected a
 # Separate Raw Rip and Finished Rip Folders for DVDs and BluRays
 # Raw Rips go in the usual folder structure
 # Finished Rips are moved to a "finished" folder in it's respective STORAGE folder
-echo "testing env pass thru"
-echo $EJECTENABLED
-SEPARATERAWFINISH="true"
-EJECTENABLED="false"
-# Paths
-STORAGE_CD="/out/Ripper/CD"
-STORAGE_DATA="/out/Ripper/DATA"
-STORAGE_DVD="/out/Ripper/DVD"
-STORAGE_BD="/out/Ripper/BluRay"
-DRIVE="/dev/sr0"
+
+# If an environment variable is not set, then set it to the default value
+: "${SEPARATERAWFINISH:=true}"
+: "${EJECTENABLED:=true}"
+: "${STORAGE_CD:=/out/Ripper/CD}"
+: "${STORAGE_DATA:=/out/Ripper/DATA}"
+: "${STORAGE_DVD:=/out/Ripper/DVD}"
+: "${STORAGE_BD:=/out/Ripper/BluRay}"
+: "${DRIVE:=/dev/sr0}"
 
 BAD_THRESHOLD=5
 let BAD_RESPONSE=0

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -7,7 +7,6 @@ LOGFILE="/config/Ripper.log"
 printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 60 seconds.\n" "$(date "+%d.%m.%Y %T")"
 
 # Set default values for configuration options if not already set
-: "${SEPARATERAWFINISH:=true}"
 : "${EJECTENABLED:=true}"
 : "${JUSTMAKEISO:=false}"
 : "${STORAGE_CD:=/out/Ripper/CD}"
@@ -17,6 +16,17 @@ printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 6
 : "${DRIVE:=/dev/sr0}"
 : "${BAD_THRESHOLD:=5}"
 : "${DEBUG:=false}"
+# Print the values of configuration options
+printf "SEPARATERAWFINISH: %s\n" "$SEPARATERAWFINISH"
+printf "EJECTENABLED: %s\n" "$EJECTENABLED"
+printf "JUSTMAKEISO: %s\n" "$JUSTMAKEISO"
+printf "STORAGE_CD: %s\n" "$STORAGE_CD"
+printf "STORAGE_DATA: %s\n" "$STORAGE_DATA"
+printf "STORAGE_DVD: %s\n" "$STORAGE_DVD"
+printf "STORAGE_BD: %s\n" "$STORAGE_BD"
+printf "DRIVE: %s\n" "$DRIVE"
+printf "BAD_THRESHOLD: %s\n" "$BAD_THRESHOLD"
+printf "DEBUG: %s\n" "$DEBUG"
 
 BAD_RESPONSE=0
 

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -26,6 +26,8 @@ cleanup_tmp_files() {
   cd - || exit
 }
 
+while true; do
+    cleanup_tmp_files
    # get disk info through makemkv and pass output to INFO
    INFO=$"$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)"
    # check INFO for optical disk

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -9,6 +9,8 @@ echo "$(date "+%d.%m.%Y %T") : Starting Ripper. Optical Discs will be detected a
 # Separate Raw Rip and Finished Rip Folders for DVDs and BluRays
 # Raw Rips go in the usual folder structure
 # Finished Rips are moved to a "finished" folder in it's respective STORAGE folder
+echo "testing env pass thru"
+echo $EJECTENABLED
 SEPARATERAWFINISH="true"
 EJECTENABLED="false"
 # Paths

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -7,15 +7,15 @@ logfile="/config/Ripper.log"
 printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 60 seconds.\n" "$(date "+%d.%m.%Y %T")"
 
 # Set default values for configuration options if not already set
-: "${separaterawfinish:=true}"
-: "${ejectenabled:=true}"
-: "${justmakeiso:=false}"
-: "${storage_cd:=/out/Ripper/CD}"
-: "${storage_data:=/out/Ripper/DATA}"
-: "${storage_dvd:=/out/Ripper/DVD}"
-: "${storage_bd:=/out/Ripper/BluRay}"
-: "${drive:=/dev/sr0}"
-: "${bad_threshold:=5}"
+: "${SEPARATERAWFINISH:=true}"
+: "${EJECTENABLED:=true}"
+: "${JUSTMAKEISO:=false}"
+: "${STORAGE_CD:=/out/Ripper/CD}"
+: "${STORAGE_DATA:=/out/Ripper/DATA}"
+: "${STORAGE_DVD:=/out/Ripper/DVD}"
+: "${STORAGE_BD:=/out/Ripper/BluRay}"
+: "${DRIVE:=/dev/sr0}"
+: "${BAD_THRESHOLD:=5}"
 
 bad_response=0
 
@@ -149,20 +149,19 @@ cleanup_tmp_files() {
 done
 
 
-# function to eject the disk
-ejectDisk() {
-   if EJECTENABLED="true"; then
-      if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
-         echo "First attempt at Ejecting Disk Succeeded"
+# function to eject the disk - now with a lower-case function name
+ejectdisk() {
+   if [[ "$EJECTENABLED" == "true" ]]; then
+      if eject -v "$DRIVE" &>/dev/null; then
+         printf "Ejecting Disk Succeeded\n"
       else
-         echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
-         echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+         printf "%s : Ejecting Disk Failed. Attempting Alternative Method.\n" "$(date "+%d.%m.%Y %T")" >> "$LOGFILE"
          sleep 2
-         sdparm --command=unlock $DRIVE
+         sdparm --command=unlock "$DRIVE"
          sleep 1
-         sdparm --command=eject $DRIVE
+         sdparm --command=eject "$DRIVE"
       fi
    else
-      echo "Ejecting Disabled"
+      printf "Ejecting Disabled\n"
    fi
 }

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ripper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-logfile="/config/Ripper.log"
+RIPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGFILE="/config/Ripper.log"
 
 # Startup Info
 printf "%s : Starting Ripper. Optical Discs will be detected and ripped within 60 seconds.\n" "$(date "+%d.%m.%Y %T")"

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RIPPER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+RIPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 LOGFILE="/config/Ripper.log"
 
 # Startup Info
@@ -22,186 +22,179 @@ BAD_THRESHOLD=5
 let BAD_RESPONSE=0
 
 # True is always true, thus loop indefinitely
-while true
-do
-# delete MakeMKV temp files
-cwd=$(pwd)
-cd /tmp
-rm -r *.tmp > /dev/null 2>&1
-cd $cwd
+while true; do
+   # delete MakeMKV temp files
+   cwd=$(pwd)
+   cd /tmp
+   rm -r *.tmp >/dev/null 2>&1
+   cd $cwd
 
-# get disk info through makemkv and pass output to INFO
-INFO=$"`makemkvcon -r --cache=1 info disc:9999 | grep DRV:0`"
-# check INFO for optical disk
-EMPTY=`echo $INFO | grep -o 'DRV:0,0,999,0,"'`
-OPEN=`echo $INFO | grep -o 'DRV:0,1,999,0,"'`
-LOADING=`echo $INFO | grep -o 'DRV:0,3,999,0,"'`
-BD1=`echo $INFO | grep -o 'DRV:0,2,999,12,"'`
-BD2=`echo $INFO | grep -o 'DRV:0,2,999,28,"'`
-DVD=`echo $INFO | grep -o 'DRV:0,2,999,1,"'`
-CD1=`echo $INFO | grep -o 'DRV:0,2,999,0,"'`
-CD2=`echo $INFO | grep -o '","","'$DRIVE'"'`
+   # get disk info through makemkv and pass output to INFO
+   INFO=$"$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)"
+   # check INFO for optical disk
+   EMPTY=$(echo $INFO | grep -o 'DRV:0,0,999,0,"')
+   OPEN=$(echo $INFO | grep -o 'DRV:0,1,999,0,"')
+   LOADING=$(echo $INFO | grep -o 'DRV:0,3,999,0,"')
+   BD1=$(echo $INFO | grep -o 'DRV:0,2,999,12,"')
+   BD2=$(echo $INFO | grep -o 'DRV:0,2,999,28,"')
+   DVD=$(echo $INFO | grep -o 'DRV:0,2,999,1,"')
+   CD1=$(echo $INFO | grep -o 'DRV:0,2,999,0,"')
+   CD2=$(echo $INFO | grep -o '","","'$DRIVE'"')
 
-# Check for trouble and respond if found
-EXPECTED="${EMPTY}${OPEN}${LOADING}${BD1}${BD2}${DVD}${CD1}${CD2}"
-if [ "x$EXPECTED" == 'x' ]; then
- echo "$(date "+%d.%m.%Y %T") : Unexpected makemkvcon output: $INFO"
- let BAD_RESPONSE++
-else
- let BAD_RESPONSE=0
-fi
-if (( $BAD_RESPONSE >= $BAD_THRESHOLD ))
-then
-  echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disk and aborting"
-  # Run makemkvcon once more with full output, to potentially aid in debugging
-  makemkvcon -r --cache=1 info disc:9999;
-  if eject -v $DRIVE | grep 'whole-disk' >> /dev/null
-  then
-    echo "First attempt at Ejecting Disk Succeeded"
-    exit 1
-  else
-    echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >> $LOGFILE 2>&1
-    echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
-    sleep 2
-    sdparm --command=unlock $DRIVE
-    sleep 1
-    sdparm --command=eject $DRIVE
-    exit 1 
-  fi
-fi
+   # Check for trouble and respond if found
+   EXPECTED="${EMPTY}${OPEN}${LOADING}${BD1}${BD2}${DVD}${CD1}${CD2}"
+   if [ "x$EXPECTED" == 'x' ]; then
+      echo "$(date "+%d.%m.%Y %T") : Unexpected makemkvcon output: $INFO"
+      let BAD_RESPONSE++
+   else
+      let BAD_RESPONSE=0
+   fi
+   if (($BAD_RESPONSE >= $BAD_THRESHOLD)); then
+      echo "$(date "+%d.%m.%Y %T") : Too many errors, ejecting disk and aborting"
+      # Run makemkvcon once more with full output, to potentially aid in debugging
+      makemkvcon -r --cache=1 info disc:9999
+      if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
+         echo "First attempt at Ejecting Disk Succeeded"
+         exit 1
+      else
+         echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
+         echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+         sleep 2
+         sdparm --command=unlock $DRIVE
+         sleep 1
+         sdparm --command=eject $DRIVE
+         exit 1
+      fi
+   fi
 
-# if [ $EMPTY = 'DRV:0,0,999,0,"' ]; then
-#  echo "$(date "+%d.%m.%Y %T") : No Disc"; &>/dev/null
-# fi
-if [ "$OPEN" = 'DRV:0,1,999,0,"' ]; then
- echo "$(date "+%d.%m.%Y %T") : Disk tray open"
-fi
-if [ "$LOADING" = 'DRV:0,3,999,0,"' ]; then
- echo "$(date "+%d.%m.%Y %T") : Disc still loading"
-fi
+   # if [ $EMPTY = 'DRV:0,0,999,0,"' ]; then
+   #  echo "$(date "+%d.%m.%Y %T") : No Disc"; &>/dev/null
+   # fi
+   if [ "$OPEN" = 'DRV:0,1,999,0,"' ]; then
+      echo "$(date "+%d.%m.%Y %T") : Disk tray open"
+   fi
+   if [ "$LOADING" = 'DRV:0,3,999,0,"' ]; then
+      echo "$(date "+%d.%m.%Y %T") : Disc still loading"
+   fi
 
-if [ "$BD1" = 'DRV:0,2,999,12,"' ] || [ "$BD2" = 'DRV:0,2,999,28,"' ]; then
- DISKLABEL=`echo $INFO | grep -o -P '(?<=",").*(?=",")'`
- BDPATH="$STORAGE_BD"/"$DISKLABEL"
- BLURAYNUM=`echo $INFO | grep $DRIVE | cut -c5`
- mkdir -p "$BDPATH"
- ALT_RIP="${RIPPER_DIR}/BLURAYrip.sh"
- if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
-    echo "$(date "+%d.%m.%Y %T") : BluRay detected: Executing $ALT_RIP"
-    $ALT_RIP "$BLURAYNUM" "$BDPATH" "$LOGFILE"
- else
-    # BluRay/MKV
-    echo "$(date "+%d.%m.%Y %T") : BluRay detected: Saving MKV"
-    makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >> $LOGFILE 2>&1
- fi
- if [ "$SEPARATERAWFINISH" = 'true' ]; then
-    BDFINISH="$STORAGE_BD"/finished/
-    mv -v "$BDPATH" "$BDFINISH"
- fi
- echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
- if eject -v $DRIVE | grep 'whole-disk' >> /dev/null
- then
-    echo "First attempt at Ejecting Disk Succeeded"
- else
-    echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >> $LOGFILE 2>&1
-    echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
-    sleep 2
-    sdparm --command=unlock $DRIVE
-    sleep 1
-    sdparm --command=eject $DRIVE 
- fi
- # permissions
- chown -R nobody:users "$STORAGE_BD" && chmod -R g+rw "$STORAGE_BD"
-fi
+   if [ "$BD1" = 'DRV:0,2,999,12,"' ] || [ "$BD2" = 'DRV:0,2,999,28,"' ]; then
+      DISKLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
+      BDPATH="$STORAGE_BD"/"$DISKLABEL"
+      BLURAYNUM=$(echo $INFO | grep $DRIVE | cut -c5)
+      mkdir -p "$BDPATH"
+      ALT_RIP="${RIPPER_DIR}/BLURAYrip.sh"
+      if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
+         echo "$(date "+%d.%m.%Y %T") : BluRay detected: Executing $ALT_RIP"
+         $ALT_RIP "$BLURAYNUM" "$BDPATH" "$LOGFILE"
+      else
+         # BluRay/MKV
+         echo "$(date "+%d.%m.%Y %T") : BluRay detected: Saving MKV"
+         makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$BLURAYNUM" all "$BDPATH" >>$LOGFILE 2>&1
+      fi
+      if [ "$SEPARATERAWFINISH" = 'true' ]; then
+         BDFINISH="$STORAGE_BD"/finished/
+         mv -v "$BDPATH" "$BDFINISH"
+      fi
+      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
+      if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
+         echo "First attempt at Ejecting Disk Succeeded"
+      else
+         echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
+         echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+         sleep 2
+         sdparm --command=unlock $DRIVE
+         sleep 1
+         sdparm --command=eject $DRIVE
+      fi
+      # permissions
+      chown -R nobody:users "$STORAGE_BD" && chmod -R g+rw "$STORAGE_BD"
+   fi
 
-if [ "$DVD" = 'DRV:0,2,999,1,"' ]; then
- DISKLABEL=`echo $INFO | grep -o -P '(?<=",").*(?=",")'` 
- DVDPATH="$STORAGE_DVD"/"$DISKLABEL"
- DVDNUM=`echo $INFO | grep $DRIVE | cut -c5`
- mkdir -p "$DVDPATH"
- ALT_RIP="${RIPPER_DIR}/DVDrip.sh"
- if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
-    echo "$(date "+%d.%m.%Y %T") : DVD detected: Executing $ALT_RIP"
-    $ALT_RIP "$DVDNUM" "$DVDPATH" "$LOGFILE"
- else
-    # DVD/MKV
-    echo "$(date "+%d.%m.%Y %T") : DVD detected: Saving MKV"
-    makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$DVDNUM" all "$DVDPATH" >> $LOGFILE 2>&1
- fi
- if [ "$SEPARATERAWFINISH" = 'true' ]; then
-    DVDFINISH="$STORAGE_DVD"/finished/
-    mv -v "$DVDPATH" "$DVDFINISH" 
- fi
- echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
- if eject -v $DRIVE | grep 'whole-disk' >> /dev/null
- then
-    echo "First attempt at Ejecting Disk Succeeded"
- else
-    echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >> $LOGFILE 2>&1
-    echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
-    sleep 2
-    sdparm --command=unlock $DRIVE
-    sleep 1
-    sdparm --command=eject $DRIVE
- fi
- # permissions
- chown -R nobody:users "$STORAGE_DVD" && chmod -R g+rw "$STORAGE_DVD"
-fi
+   if [ "$DVD" = 'DRV:0,2,999,1,"' ]; then
+      DISKLABEL=$(echo $INFO | grep -o -P '(?<=",").*(?=",")')
+      DVDPATH="$STORAGE_DVD"/"$DISKLABEL"
+      DVDNUM=$(echo $INFO | grep $DRIVE | cut -c5)
+      mkdir -p "$DVDPATH"
+      ALT_RIP="${RIPPER_DIR}/DVDrip.sh"
+      if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
+         echo "$(date "+%d.%m.%Y %T") : DVD detected: Executing $ALT_RIP"
+         $ALT_RIP "$DVDNUM" "$DVDPATH" "$LOGFILE"
+      else
+         # DVD/MKV
+         echo "$(date "+%d.%m.%Y %T") : DVD detected: Saving MKV"
+         makemkvcon --profile=/config/default.mmcp.xml -r --decrypt --minlength=600 mkv disc:"$DVDNUM" all "$DVDPATH" >>$LOGFILE 2>&1
+      fi
+      if [ "$SEPARATERAWFINISH" = 'true' ]; then
+         DVDFINISH="$STORAGE_DVD"/finished/
+         mv -v "$DVDPATH" "$DVDFINISH"
+      fi
+      echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
+      if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
+         echo "First attempt at Ejecting Disk Succeeded"
+      else
+         echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
+         echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+         sleep 2
+         sdparm --command=unlock $DRIVE
+         sleep 1
+         sdparm --command=eject $DRIVE
+      fi
+      # permissions
+      chown -R nobody:users "$STORAGE_DVD" && chmod -R g+rw "$STORAGE_DVD"
+   fi
 
-if [ "$CD1" = 'DRV:0,2,999,0,"' ]; then
- if [ "$CD2" = '","","'$DRIVE'"' ]; then
-  ALT_RIP="${RIPPER_DIR}/CDrip.sh"
-  if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
-     echo "$(date "+%d.%m.%Y %T") : CD detected: Executing $ALT_RIP"
-     $ALT_RIP "$DRIVE" "$STORAGE_CD" "$LOGFILE"
-  else
-     # MP3 & FLAC
-     echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC" 
-     /usr/bin/abcde -d "$DRIVE" -c /ripper/abcde.conf -N -x -l >> $LOGFILE 2>&1
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-  if eject -v $DRIVE | grep 'whole-disk' >> /dev/null
-  then
-     echo "First attempt at Ejecting Disk Succeeded"
-  else
-     echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >> $LOGFILE 2>&1
-     echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
-     sleep 2
-     sdparm --command=unlock $DRIVE
-     sleep 1
-     sdparm --command=eject $DRIVE 
-  fi
-  # permissions
-  chown -R nobody:users "$STORAGE_CD" && chmod -R g+rw "$STORAGE_CD"
- else
-  DISKLABEL=`echo $INFO | grep $DRIVE | grep -o -P '(?<=",").*(?=",")'`  
-  ISOPATH="$STORAGE_DATA"/"$DISKLABEL"/"$DISKLABEL".iso
-  mkdir -p "$STORAGE_DATA"/"$DISKLABEL"
-  ALT_RIP="${RIPPER_DIR}/DATArip.sh"
-  if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
-     echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Executing $ALT_RIP"
-     $ALT_RIP "$DRIVE" "$ISOPATH" "$LOGFILE"
-  else
-     # ISO
-     echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Saving ISO"
-     ddrescue $DRIVE "$ISOPATH" >> $LOGFILE 2>&1
-  fi
-  echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
-  if eject -v $DRIVE | grep 'whole-disk' >> /dev/null
-  then
-     echo "First attempt at Ejecting Disk Succeeded"
-  else
-     echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >> $LOGFILE 2>&1
-     echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
-     sleep 2
-     sdparm --command=unlock $DRIVE
-     sleep 1
-     sdparm --command=eject $DRIVE 
-  fi
-# permissions
-  chown -R nobody:users "$STORAGE_DATA" && chmod -R g+rw "$STORAGE_DATA"
- fi
-fi
-# Wait a minute
-sleep 1m
+   if [ "$CD1" = 'DRV:0,2,999,0,"' ]; then
+      if [ "$CD2" = '","","'$DRIVE'"' ]; then
+         ALT_RIP="${RIPPER_DIR}/CDrip.sh"
+         if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
+            echo "$(date "+%d.%m.%Y %T") : CD detected: Executing $ALT_RIP"
+            $ALT_RIP "$DRIVE" "$STORAGE_CD" "$LOGFILE"
+         else
+            # MP3 & FLAC
+            echo "$(date "+%d.%m.%Y %T") : CD detected: Saving MP3 and FLAC"
+            /usr/bin/abcde -d "$DRIVE" -c /ripper/abcde.conf -N -x -l >>$LOGFILE 2>&1
+         fi
+         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
+         if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
+            echo "First attempt at Ejecting Disk Succeeded"
+         else
+            echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
+            echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+            sleep 2
+            sdparm --command=unlock $DRIVE
+            sleep 1
+            sdparm --command=eject $DRIVE
+         fi
+         # permissions
+         chown -R nobody:users "$STORAGE_CD" && chmod -R g+rw "$STORAGE_CD"
+      else
+         DISKLABEL=$(echo $INFO | grep $DRIVE | grep -o -P '(?<=",").*(?=",")')
+         ISOPATH="$STORAGE_DATA"/"$DISKLABEL"/"$DISKLABEL".iso
+         mkdir -p "$STORAGE_DATA"/"$DISKLABEL"
+         ALT_RIP="${RIPPER_DIR}/DATArip.sh"
+         if [[ -f $ALT_RIP && -x $ALT_RIP ]]; then
+            echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Executing $ALT_RIP"
+            $ALT_RIP "$DRIVE" "$ISOPATH" "$LOGFILE"
+         else
+            # ISO
+            echo "$(date "+%d.%m.%Y %T") : Data-Disk detected: Saving ISO"
+            ddrescue $DRIVE "$ISOPATH" >>$LOGFILE 2>&1
+         fi
+         echo "$(date "+%d.%m.%Y %T") : Done! Ejecting Disk"
+         if eject -v $DRIVE | grep 'whole-disk' >>/dev/null; then
+            echo "First attempt at Ejecting Disk Succeeded"
+         else
+            echo "First Attempt At Ejecting Disk Failed. Attempting Alternative Method." >>$LOGFILE 2>&1
+            echo "$(date "+%d.%m.%Y %T") : First Attempt At Ejecting Disk Failed. Trying Alternative Method."
+            sleep 2
+            sdparm --command=unlock $DRIVE
+            sleep 1
+            sdparm --command=eject $DRIVE
+         fi
+         # permissions
+         chown -R nobody:users "$STORAGE_DATA" && chmod -R g+rw "$STORAGE_DATA"
+      fi
+   fi
+   # Wait a minute
+   sleep 1m
 done

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -61,22 +61,22 @@ debug_log() {
 }
 
 get_timestamp() {
-    echo "$(date "+%Y%m%d_%H%M%S")"
+   echo "$(date "+%Y%m%d_%H%M%S")"
 }
 
 get_disc_directory() {
-    local storage_root="$1"
-    local disc_label="$2"
-    local timestamp_prefix="$3"
-    local disc_directory=""
-    
-    if [[ "$TIMESTAMPPREFIX" == "true" ]]; then
-        disc_directory="${storage_root}/$(get_timestamp)_${disc_label}"
-    else
-        disc_directory="${storage_root}/${disc_label}"
-    fi
-    
-    echo "$disc_directory"
+   local storage_root="$1"
+   local disc_label="$2"
+   local timestamp_prefix="$3"
+   local disc_directory=""
+
+   if [[ "$TIMESTAMPPREFIX" == "true" ]]; then
+      disc_directory="${storage_root}/$(get_timestamp)_${disc_label}"
+   else
+      disc_directory="${storage_root}/${disc_label}"
+   fi
+
+   echo "$disc_directory"
 }
 
 cleanup_tmp_files() {


### PR DESCRIPTION
## Overview

This pull request introduces significant updates to the docker-ripper project, aiming to enhance the readability and add flexibility to Docker configurations.

## Key Changes

- Updated output formats for various disk types, including addition of ISO format.
- Added debug logging environment variable `DEBUGTOWEB`  to aid in monitoring and troubleshooting.
- Added debug logging in console with environment variable `DEBUG`
- Introduced several new environment variables to control behavior and added default values to improve user experience. 
- Refined `docker-compose.yml` to include more configuration options with explanations for each and definitions for building the images.
- Improved `Dockerfile` for both `latest` and manual build to optimize space and improve readability. 

## Docker Compose Adjustments

The provided `docker-compose.yml` now includes configurations that allow users to:

- Customize whether to eject disks post-ripping (`EJECTENABLED`).
- Choose to create ISO images exclusively or as part of the normal ripping process (`JUSTMAKEISO` and `ALSOMAKEISO`).
- Set storage paths depending on the type of disk being ripped.
- Optionally Affix timestamps to output folders for better organization.
- Opt to use built images or build from provided Dockerfiles (`latest` and `manual-build` options) in the compose file


## Building the Image:
The README now also contains simplified instructions for building and running the project using Docker Compose:

Clone the repository
Navigate to the repo directory
Build the image using `docker compose build`
Run the container using `docker compose up -d`



## Asks
- I do not have any BluRay discs to test these changes out with; however, the code that actually starts makemkv has not been touched.  I would recommend this be tested before merging. 

## Updates
2024-01-27 - Changed to Draft, investigating use of chmod, testing
