### PR TITLE
move ejectdisc to after ALSOMAKEISO check

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -317,9 +317,9 @@ launcher_function() {
                   if [ "$JUST_MADE_ISO" = false ]; then
                      handle_data_disc "$INFO"
                   fi
-                  ejectdisc
                   ;;
                esac
+               ejectdisc
                ;;
             esac
          else


### PR DESCRIPTION
Currently the ripping of CDs results in disc being ejected *by abcde* but ripping of DVDs just keeps going round and around overwriting the the file again and again because the disc never gets ejected after it is finished...

On checking the script, there's no call to ejectdisc in the normal processing of things unless you also set ALSOMAKEISO to true