### PR TITLE
Add chown/chmod to move_to_finished

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -224,6 +224,8 @@ move_to_finished() {
       debug_log "Moved $src_path to $finish_path"
    else
       debug_log "SEPARATERAWFINISH is disabled, not moving $src_path"
+      chown -R nobody:users "$src_path" && chmod -R g+rw "$src_path"
+      debug_log "Changed owner and permissions for: $src_path"
    fi
 }
 


### PR DESCRIPTION
If SEPARATERAWFINISH is true, files get moved from the source directory to the finish path, after which they're chown'ed/chmod'ed

However, this defaults to false, in which case files are left in the source folder with incorrect permissions. 

Adding an extra step within move_to_finished so that if SEPARATERAWFINISH is not true, we apply the chown/chmod to the files in the src_path