### PR TITLE
Add EYED3 options in config

### DIFF
--- a/root/ripper/abcde.conf
+++ b/root/ripper/abcde.conf
@@ -96,3 +96,9 @@ EXTRAVERBOSE=2                          # Useful for debugging
 COMMENT='abcde version 2.9.3'           # Place a comment...
 EJECTCD=y                               # Please eject cd when finished :-)
 INTERACTIVE=n
+
+# If passed genre is 255, the ID3 tags will be empty
+# This option will handle this - for details see
+# section "eyed3.id3:WARNING: Invalid numeric genre"
+# https://wiki.ubuntuusers.de/abcde/
+# EYED3OPTS="--non-std-genres"


### PR DESCRIPTION
In case abcde detects an unknown genre, the genre ID will be 255. EYED3 cannot handle genres with this ID and the result will be empty ID3 tags. Passing the option EYED3OPTS="--non-std-genres" to EYED3 the ID3 tags will be populated with all other information and genre=255.

Added hint, source and commented option to abcde.conf file.

Thanks for this gread container!