### PR TITLE
Fixes permission error when running on a filesystem with noexec set

### DIFF
--- a/root/etc/my_init.d/ripper.sh
+++ b/root/etc/my_init.d/ripper.sh
@@ -42,4 +42,4 @@ chmod -R g+rw /config
 
 chmod +x /config/ripper.sh
 
-/config/ripper.sh &
+bash /config/ripper.sh &


### PR DESCRIPTION
If ripper is created on a filesystem with noexec set, then a permission denied happens when trying to run any .sh file directly:

```
Ripper  | /etc/my_init.d/ripper.sh: line 45: /config/ripper.sh: Permission denied
```

Logging into the container I see the same:

```
root@bf76650b6ac1:/config# ./ripper.sh
bash: ./ripper.sh: Permission denied
```

There is a simple fix though, by calling bash directly on the script it works fine, as it's no longer 'executing' the file directly on the noexec filesystem

```
root@bf76650b6ac1:/config#  bash /config/ripper.sh
28.09.2024 21:21:33 : Starting Ripper. Optical Discs will be detected and ripped within 60 seconds.
```

This change works for both exec and noexec filesystems