### PR TITLE
Base Update, New PIP Install Method & Bug Fixes

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0
+FROM phusion/baseimage:noble-1.0.0
 LABEL maintainer="rix1337"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -34,7 +34,9 @@ RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \
       makemkv-oss \
       mkcue \
       python3 \
-      python3-pip \
+      python3-docopt \
+      python3-flask \
+      python3-waitress \
       sdparm \
       speex \
       vorbis-tools \
@@ -43,12 +45,6 @@ RUN add-apt-repository -y ppa:heyarje/makemkv-beta && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install python packages for web ui
-RUN pip3 install --no-cache-dir \
-    docopt \
-    flask \
-    waitress
 
 # Move Files and set permissions
 COPY root/ /

--- a/manual-build/Dockerfile
+++ b/manual-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0
+FROM phusion/baseimage:noble-1.0.0
 LABEL maintainer="rix1337"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -19,23 +19,24 @@ RUN usermod -u 99 nobody && \
 # Install Required packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    python3 \
-    python3-pip \
-    eject \
-    sdparm \
-    gddrescue \
     abcde \
+    eject \
     eyed3 \
     ffmpeg \
     flac \
+    gddrescue \
+    id3 \
+    id3v2 \
     lame \
     mkcue \
+    python3 \
+    python3-docopt \
+    python3-flask \
+    python3-waitress \
+    sdparm \
     speex \
     vorbis-tools \
-    vorbisgain \
-    id3 \
-    id3v2 && \
-    pip3 install --no-cache-dir docopt flask waitress && \
+    vorbisgain && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This PR has fixes for https://github.com/rix1337/docker-ripper/issues/121 & https://github.com/rix1337/docker-ripper/issues/120 which are updating the base image to `phusion/baseimage:noble-1.0.0` and installing python libraries via the new method (i.e. `sudo apt install -y python3-flask`)