### PR TITLE
Handle custom drive paths

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -48,13 +48,13 @@ BAD_RESPONSE=0
 DISC_TYPE=""
 # Define the drive types and patterns to match against the output of makemkvcon
 declare -A DRIVE_TYPE_PATTERNS=(
-   [empty]='DRV:[0-9],0,999,0,"'
-   [open]='DRV:[0-9],1,999,0,"'
-   [loading]='DRV:[0-9],3,999,0,"'
-   [bd1]='DRV:[0-9],2,999,12,"'
-   [bd2]='DRV:[0-9],2,999,28,"'
-   [dvd]='DRV:[0-9],2,999,1,"'
-   [cd1]='DRV:[0-9],2,999,0,"'
+   [empty]='DRV:[0-9]+,0,999,0,"'
+   [open]='DRV:[0-9]+,1,999,0,"'
+   [loading]='DRV:[0-9]+,3,999,0,"'
+   [bd1]='DRV:[0-9]+,2,999,12,"'
+   [bd2]='DRV:[0-9]+,2,999,28,"'
+   [dvd]='DRV:[0-9]+,2,999,1,"'
+   [cd1]='DRV:[0-9]+,2,999,0,"'
    [cd2]='","","'$DRIVE'"'
 )
 

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -103,7 +103,7 @@ check_disc() {
 
    for TYPE in "${!DRIVE_TYPE_PATTERNS[@]}"; do
       PATTERN=${DRIVE_TYPE_PATTERNS[$TYPE]}
-      if echo "$INFO" | grep -q "$PATTERN"; then
+      if echo "$INFO" | grep -E -q "$PATTERN"; then
          DISC_TYPE=$TYPE
          debug_log "Detected disc type: $DISC_TYPE"
          break

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -48,13 +48,13 @@ BAD_RESPONSE=0
 DISC_TYPE=""
 # Define the drive types and patterns to match against the output of makemkvcon
 declare -A DRIVE_TYPE_PATTERNS=(
-   [empty]='DRV:0,0,999,0,"'
-   [open]='DRV:0,1,999,0,"'
-   [loading]='DRV:0,3,999,0,"'
-   [bd1]='DRV:0,2,999,12,"'
-   [bd2]='DRV:0,2,999,28,"'
-   [dvd]='DRV:0,2,999,1,"'
-   [cd1]='DRV:0,2,999,0,"'
+   [empty]='DRV:[0-9],0,999,0,"'
+   [open]='DRV:[0-9],1,999,0,"'
+   [loading]='DRV:[0-9],3,999,0,"'
+   [bd1]='DRV:[0-9],2,999,12,"'
+   [bd2]='DRV:[0-9],2,999,28,"'
+   [dvd]='DRV:[0-9],2,999,1,"'
+   [cd1]='DRV:[0-9],2,999,0,"'
    [cd2]='","","'$DRIVE'"'
 )
 
@@ -97,7 +97,7 @@ cleanup_tmp_files() {
 
 check_disc() {
    debug_log "Checking disc."
-   INFO=$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:0)
+   INFO=$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:.*$DRIVE)
    debug_log "INFO: $INFO"
    DISC_TYPE="" # Clear previous disc type value
 


### PR DESCRIPTION
I couldn't work out why this kept saying my disc drive was empty and therefore refused to import anything, then realised that the `0` in the `DRV:0...` text from `makemkvcon` stands for the number in `/dev/sr0`. 

In my case, I'm using a VM which still has the default QEMU drive attached to `/dev/sr0`, and a USB disc drive attached to `/dev/sr1`.

Conveniently - and as you noted with the `cd2` mapping - `makemkvcon` ends the string with the drive path.

This PR sets it up to return the string starting with `DRV` and ending with the drive path in the `$DRIVE` environment variable, while also setting up the `DRIVE_TYPE_PATTERNS` to accept any digit after `DRV:` -- but still requiring the important parts afterwards to be valid. Otherwise, all custom drive paths will be handled as a CD.