### PR TITLE
Fix audio CD detection: add --noscan, timeout, and cdparanoia fallback Fixes #145

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -99,7 +99,7 @@ cleanup_tmp_files() {
 
 check_disc() {
    debug_log "Checking disc."
-   INFO=$(makemkvcon -r --cache=1 info disc:9999 | grep DRV:.*$DRIVE)
+   INFO=$(timeout 30s makemkvcon -r --cache=1 --noscan info disc:9999 | grep DRV:.*$DRIVE)
    debug_log "INFO: $INFO"
    DISC_TYPE="" # Clear previous disc type value
 
@@ -111,6 +111,14 @@ check_disc() {
          break
       fi
    done
+
+   # If MakeMKV reports empty, double-check with cdparanoia for audio CDs
+   if [[ "$DISC_TYPE" == "empty" ]]; then
+      if cdparanoia -d "$DRIVE" -Q 2>&1 | grep -q "audio tracks"; then
+         DISC_TYPE="cd1"
+         debug_log "Audio CD detected via cdparanoia fallback."
+      fi
+   fi
 
    if [[ -z "$DISC_TYPE" ]]; then
       printf "%s : Unexpected makemkvcon output: %s\n" "$(date "+%d.%m.%Y %T")" "$INFO"


### PR DESCRIPTION
Problem
Audio CD detection has been broken for drives where makemkvcon cannot interrogate audio CDs. Two bugs combine to cause complete silence in the logs when an audio CD is inserted:

makemkvcon without --noscan hangs indefinitely when attempting to read an audio CD, freezing the check_disc function and the entire script with it.
Even with --noscan, makemkvcon reports audio CDs with status code 0 — the same code used for an empty drive — making it impossible to distinguish between the two using MakeMKV alone.

Fix
Two changes to check_disc in ripper.sh:

Added --noscan and timeout 30s to the makemkvcon call to prevent indefinite hangs.
Added a cdparanoia fallback: when MakeMKV reports the drive as empty, cdparanoia is used to check for audio tracks. If found, DISC_TYPE is overridden to cd1 and ripping proceeds normally.

Tested on

Unraid 7.1.4
Docker 27.5.1
Drive: HL-DT-ST BD-RE WH10LS30
Successfully ripped 3 audio CDs after applying the fix