### PR TITLE
Remove noscan

### DIFF
--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -99,11 +99,7 @@ cleanup_tmp_files() {
 
 check_disc() {
    debug_log "Checking disc."
-   INFO=$(timeout 30s makemkvcon -r --cache=1 --noscan info disc:9999 | grep DRV:.*$DRIVE)
-   if echo "$INFO" | grep -E -q 'DRV:[0-9]+,0,999,0,"'; then
-     debug_log "Fast scan reported empty; retrying with full scan."
-     INFO=$(timeout 60s makemkvcon -r --cache=1 info disc:9999 | grep "DRV:.*$DRIVE")
-   fi
+   INFO=$(timeout 30s makemkvcon -r --cache=1 info disc:9999 | grep DRV:.*$DRIVE)
    debug_log "INFO: $INFO"
    DISC_TYPE="" # Clear previous disc type value
 

--- a/root/ripper/ripper.sh
+++ b/root/ripper/ripper.sh
@@ -100,6 +100,10 @@ cleanup_tmp_files() {
 check_disc() {
    debug_log "Checking disc."
    INFO=$(timeout 30s makemkvcon -r --cache=1 --noscan info disc:9999 | grep DRV:.*$DRIVE)
+   if echo "$INFO" | grep -E -q 'DRV:[0-9]+,0,999,0,"'; then
+     debug_log "Fast scan reported empty; retrying with full scan."
+     INFO=$(timeout 60s makemkvcon -r --cache=1 info disc:9999 | grep "DRV:.*$DRIVE")
+   fi
    debug_log "INFO: $INFO"
    DISC_TYPE="" # Clear previous disc type value
 


### PR DESCRIPTION
In fixing issue #145, the noscan option was added to avoid makemkvcon stalling. However, that means it doesn't properly read any discs that makemkv would normally handle.

Removed the noscan as the timeout at the front should be sufficient. Tested on my hardware.